### PR TITLE
Widen calo cluster association time window

### DIFF
--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -180,7 +180,7 @@ Mu2eKinKalTrigger : {
       AddHits : false
       AddMaterial : false
       MaterialCorrection : true
-      MaxCaloClusterDt : 10.0
+      MaxCaloClusterDt : 25.0 # loose timing cut; needed for DeP for now TODO
       MaxCaloClusterDOCA : 150.0 # mm
       SampleSurfaces : ["TT_Mid"]
       ExtendSurfaces : ["TT_Mid"]

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -24,15 +24,15 @@ TrigTrkPaths:{
    #    @sequence::TrigRecoSequences.trkPrepareHits,
    #    TTtimeClusterFinder, tprTimeClusterDePTCFilter ]
 
-   tprDeM_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   tprDeM_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen,
       tprDeMHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDeM, tprDeMHighPStopTargHSFilter, TTKSFDeM, tprDeMHighPStopTargTSFilter, tprDeMHighPStopTargTriggerInfoMerger ]
-   trpDeM               : [ tprDeMHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
+   tprDeM               : [ tprDeMHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDeM, tprDeMHighPStopTargHSFilter, TTKSFDeM, tprDeMHighPStopTargTSFilter, tprDeMHighPStopTargTriggerInfoMerger ]
 
-   tprDeP_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   tprDeP_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen,
       tprDePHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTtimeClusterFinder, tprDePHighPStopTargTCFilter, TThelixFinder,TTHelixMergerDeP,  tprDePHighPStopTargHSFilter, TTKSFDeP, tprDePHighPStopTargTSFilter, tprDePHighPStopTargTriggerInfoMerger  ]
@@ -251,27 +251,27 @@ TrigTrkPaths:{
 }
 
 TrigCaloPaths: {
-   caloFast_cosmic: [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   caloFast_cosmic: [ @sequence::TrigRecoSequences.artFragmentsGen,
       "caloFastCosmicPS",
       @sequence::TrigRecoSequences.calReco,
       "caloFastCosmicFilter"
    ]
-   caloFast_MVANNCE: [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   caloFast_MVANNCE: [ @sequence::TrigRecoSequences.artFragmentsGen,
       "caloFastMVANNCEPS",
       @sequence::TrigRecoSequences.calReco,
       "caloFastMVANNCEFilter"
    ]
-   caloFast_photon: [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   caloFast_photon: [ @sequence::TrigRecoSequences.artFragmentsGen,
       "caloFastPhotonPS",
       @sequence::TrigRecoSequences.calReco,
       "caloFastPhotonFilter"
    ]
-   caloFast_RMC: [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   caloFast_RMC: [ @sequence::TrigRecoSequences.artFragmentsGen,
       "caloFastRMCPS",
       @sequence::TrigRecoSequences.calReco,
       "caloFastRMCFilter"
    ]
-   
+
 }
 
 TrigCstPaths: {
@@ -300,7 +300,7 @@ TrigCstPaths: {
       cstTimeClusterSDCountFilter,
       CstSimpleTimeCluster, cstTimeClusterTCFilter, cstTimeClusterTriggerInfoMerger ]
 
-   
+
 }
 
 TrigSupPaths:{
@@ -329,6 +329,6 @@ TrigSequences:{
    @table::TrigCstPaths
    @table::TrigSupPaths
 
-}   
+}
 
 END_PROLOG


### PR DESCRIPTION
This 'fixes' the problem with KKDeP not getting calo clusters associated.  There is still an underlying bug, probably in the time cluster, as the standard window works fine for KKDeM and KKCalDeP, but this patches things for now.