### PR TITLE
Change  to CaloCosmicCalib cuts

### DIFF
--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -943,8 +943,8 @@ TrigCalFilters:{
       CaloClusterModuleLabel: "CaloClusterFast"
       InnerRadius: 460
       MaxEnergy: 600
-      MinCelEneCut: 15
-      MinEnergy: 120
+      MinCelEneCut: 12
+      MinEnergy: 90
       MinNCrystalHits: 0
       MinNumCeldiagver: 6
       MinNumCelinout: 6


### PR DESCRIPTION
Changes to restore efficiency due to change in Geant4 dE/dx simulation (see doc-db 47293)