### PR TITLE
Add HighPStoptarg trigger line using RobustMultiHelixFinder

### DIFF
--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -253,7 +253,7 @@ TrigCprFilters:{
    cprDeHighPStopTargKSFilter: {
       kalSeedCollection: "TTCalSeedFitDe"
       module_type: "KalSeedFilter"
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for downstreeam e-minus
             fitdirection: 0
             fitparticle: 11
@@ -343,7 +343,7 @@ TrigCprFilters:{
    cprDeLowPStopTargKSFilter: {
       kalSeedCollection: "TTCalSeedFitDe"
       module_type: "KalSeedFilter"
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for downstream e-minus
             fitdirection: 0
             fitparticle: 11
@@ -424,7 +424,7 @@ TrigCprFilters:{
          prescaleUsingD0Phi: false
          requireCaloCluster: false
       }
-      
+
    }
 
    cprHelixDeTCFilter: {
@@ -433,7 +433,7 @@ TrigCprFilters:{
       requireCaloCluster: false
       timeClusterCollection: "TTCalTimePeakFinder"
    }
-   
+
    cprHelixUeHSFilter: {
       module_type: "HelixFilter"
       helixSeedCollection: "TTCalHelixMergerUe"
@@ -533,18 +533,18 @@ TrigTprFilters:{
          requireCaloCluster: false
       }
    }
-   
+
    tprDeHighPStopTargTCFilter: {
       minNStrawHits: 15
       module_type: "TimeClusterFilter"
       requireCaloCluster: false
       timeClusterCollection: "TTtimeClusterFinder"
    }
-   
+
    tprDeHighPStopTargKSFilter: {
       module_type: "KalSeedFilter"
       kalSeedCollection: "TTKSFDe"
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for doesntream e-minus
             fitdirection: 0
             fitparticle: 11
@@ -583,7 +583,7 @@ TrigTprFilters:{
          }
       ]
    }
-   
+
    tprDeLowPStopTargHSFilter: {
       module_type: "HelixFilter"
       helixSeedCollection: "TTHelixMergerDe"
@@ -626,7 +626,7 @@ TrigTprFilters:{
          requireCaloCluster: false
       }
    }
-   
+
    tprDeLowPStopTargTCFilter: {
       minNStrawHits: 10
       module_type: "TimeClusterFilter"
@@ -718,7 +718,7 @@ TrigTprFilters:{
          requireCaloCluster: false
       }
    }
-   
+
    tprHelixDeIpaHSFilter: {
       helixSeedCollection: "TTHelixMergerDe"
       module_type: "HelixFilter"
@@ -844,6 +844,104 @@ TrigTprFilters:{
       module_type: "TimeClusterFilter"
       requireCaloCluster: false
       timeClusterCollection: "TTtimeClusterFinderUe"
+   }
+}################################################################################
+#
+#
+#
+################################################################################
+TrigMprFilters:{
+   mprDeHighPStopTargHSFilter: {
+      module_type: "HelixFilter"
+      helixSeedCollection: "TTMprHelixMergerDe"
+      posHelicitySelection : {
+         configured: true
+         doHelicityCheck: false
+         maxAbsLambda: 300
+         maxChi2PhiZ: 8
+         maxChi2XY: 8
+         maxD0: 300
+         maxMomentum: 500
+         maxNLoops: 30
+         minAbsLambda: 140
+         minD0: -150
+         minHitRatio: 4e-1
+         minMomentum: 70
+         minNLoops: 0
+         minNStrawHits: 15
+         minPt: 0
+         prescaleUsingD0Phi: false
+         requireCaloCluster: false
+      }
+      negHelicitySelection : {
+         configured: true
+         doHelicityCheck: false
+         maxAbsLambda: 330
+         maxChi2PhiZ: 8
+         maxChi2XY: 8
+         maxD0: 300
+         maxMomentum: 500
+         maxNLoops: 30
+         minAbsLambda: 100
+         minD0: -150
+         minHitRatio: 4e-1
+         minMomentum: 60
+         minNLoops: 0
+         minNStrawHits: 15
+         minPt: 0
+         prescaleUsingD0Phi: false
+         requireCaloCluster: false
+      }
+   }
+
+   mprDeHighPStopTargTCFilter: {
+     minNStrawHits: 15
+      module_type: "TimeClusterFilter"
+      requireCaloCluster: false
+      timeClusterCollection: "TTtimeClusterFinder"
+   }
+
+   mprDeHighPStopTargKSFilter: {
+      module_type: "KalSeedFilter"
+      kalSeedCollection: "TTMprKSFDe"
+      KalSeedCuts : [
+         { #cuts for doesntream e-minus
+            fitdirection: 0
+            fitparticle: 11
+            doParticleTypeCheck: true
+            doZPropDirCheck: true
+            maxChi2DOF: 20
+            maxD0: 200
+            maxMomErr: 10
+            maxMomentum: 500
+            maxTanDip: 100
+            minD0: -200
+            minFitCons: -1
+            minMomentum: 80
+            minNStrawHits: 15
+            minT0: 0
+            minTanDip: 0
+            requireCaloCluster: false
+         },
+         {
+            fitdirection: 0
+            fitparticle: -11
+            doParticleTypeCheck: true
+            doZPropDirCheck: true
+            maxChi2DOF: 20
+            maxD0: 200
+            maxMomErr: 10
+            maxMomentum: 500
+            maxTanDip: 100
+            minD0: -200
+            minFitCons: -1
+            minMomentum: 70
+            minNStrawHits: 15
+            minT0: 0
+            minTanDip: 0
+            requireCaloCluster: false
+         }
+      ]
    }
 }
 
@@ -994,7 +1092,7 @@ TrigAprFilters:{
    aprHighPStopTargKSFilter: {
       kalSeedCollection: "TTAprKSF"
       module_type: "KalSeedFilter"
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for downstreeam e-minus
             doParticleTypeCheck: false
             doZPropDirCheck: true
@@ -1086,7 +1184,7 @@ TrigAprFilters:{
    aprLowPStopTargKSFilter: {
       kalSeedCollection: "TTAprKSF"
       module_type: "KalSeedFilter"
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for downstreeam e-minus
             doParticleTypeCheck: false
             doZPropDirCheck: true
@@ -1179,7 +1277,7 @@ TrigAprFilters:{
       kalSeedCollection: "TTAprKSF"
       module_type: "KalSeedFilter"
       minNTrks: 2
-      KalSeedCuts : [ 
+      KalSeedCuts : [
          { #cuts for downstreeam e-minus
             doParticleTypeCheck: false
             doZPropDirCheck: true
@@ -1343,6 +1441,7 @@ TrigFilters : {
       @table::TrigCprFilters
       @table::TrigTprFilters
       @table::TrigAprFilters
+      @table::TrigMprFilters
       @table::TrigCstFilters
       @table::TrigSupFilters
       @table::TrigCalFilters

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -600,6 +600,65 @@ TrigTprProducers : {
    }
 }
 
+TrigMprProducers : {
+
+  TTRobustMultiHelixFinder : {
+    module_type   : RobustMultiHelixFinder
+    ComboHitCollection      : "TTflagBkgHits"
+    TimeClusterCollection   : "TTtimeClusterFinder"
+    Helicities              : [-1,1]
+    MinDRCircle             : 40
+    MinRadCircle            : 150
+    MaxRadCircle            : 350
+    MinDXY2Circle           : 1600
+    ClusteringPhiBin        : 0.1
+    ClusteringMinBin        : 30
+    TargetCon               : false
+    TargetRadius            : 150
+    MinDPDZSlope            : 150
+    MaxDPDZSlope            : 350
+    DPDZStep                : 25
+    MaxDPhiHelInit          : 1.0
+    MaxDPhiHelFit           : 0.7
+    MaxDTHelFit             : 25
+    CaloClusterMinE         : 30
+    CaloClusterWeight       : 5
+    MaxChi2Hit              : 50
+    MinDZTrk                : 1500
+    FitCircleStrategy       : "ChiSquared"  # this is just a guess FIXME
+    MinStrawHits            : 10
+    NMaxTrkIter             : 3
+    DiagLevel               : 0
+  }
+  TTMprHelixMergerDe: {
+    HelixFinders: [ "TTRobustMultiHelixFinder" ]
+    debugLevel: 0
+    deltanh: 5
+    module_type: "MergeHelices"
+    scaleXY: 1.1
+    scaleZPhi: 7.5e-1
+    MinHitOverlapFraction: 0.5
+    MinNHitOverlap: 10
+  }
+  TTMprKSFDe: {
+    module_type : LoopHelixFit
+    MaterialSettings : { @table::Mu2eKinKalTrigger.MAT     }
+    KKFitSettings    : { @table::Mu2eKinKalTrigger.KKFIT   }
+    FitSettings      : { @table::Mu2eKinKalTrigger.SEEDFIT }
+    ExtensionSettings: { @table::Mu2eKinKalTrigger.SEEDEXT }
+    ModuleSettings   : {
+      @table::Mu2eKinKalTrigger.LOOPHELIX
+      FitParticle : 11
+      HelixSeedCollections   : [ "TTMprHelixMergerDe" ]
+    }
+    UsePDGCharge     : false
+    FitDirection     : 0
+  }
+
+  mprDeHighPStopTargTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
+}
 ################################################################################
 #
 #
@@ -668,13 +727,13 @@ TrigAprProducers : {
       chCollLabel2               : "TTmakeSH"
       ccCollLabel                : "CaloClusterFast"
    }
-   
+
    TTAprHelixFinder: { @table::CalPatRec.producers.AgnosticHelixFinder
       chCollLabel             : "TTflagBkgHits"
       tcCollLabel             : "TTTZClusterFinder"
       ccCollLabel             : "CaloClusterFast"
    }
-   
+
    TTAprHelixMerger: {
       HelixFinders: [
          "TTAprHelixFinder"
@@ -791,6 +850,7 @@ TrigProducers : {
       @table::TrigTprProducers
       @table::TrigCprProducers
       @table::TrigAprProducers
+      @table::TrigMprProducers
       @table::TrigCstProducers
    }
 }

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -631,7 +631,7 @@ TrigMprProducers : {
     DiagLevel               : 0
   }
   TTMprHelixMergerDe: {
-    HelixFinders: [ "TTRobustMultiHelixFinder" ]
+    HelixFinders: [ "TTRobustMultiHelixFinder:Positive" ]
     debugLevel: 0
     deltanh: 5
     module_type: "MergeHelices"

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -15,6 +15,11 @@ BEGIN_PROLOG
 # }
 
 TrigTrkPaths:{
+   mprDe_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen,
+      mprDeHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTtimeClusterFinder, mprDeHighPStopTargTCFilter, TTRobustMultiHelixFinder, TTMprHelixMergerDe, mprDeHighPStopTargHSFilter, TTMprKSFDe, mprDeHighPStopTargKSFilter, mprDeHighPStopTargTriggerInfoMerger ]
+
    #trkpatrec tracking
    # tprTimeClusterDe    : [ tprTimeClusterDeEventPrescale,
    #    @sequence::TrigRecoSequences.calReco,
@@ -143,45 +148,45 @@ TrigTrkPaths:{
    #    TTtimeClusterFinder, tprDeHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDe, tprDeHighPStopTargHSFilter,
    #    TTKSFDe, tprDeHighPStopTargKSFilter, TTKFFDe, tprDeHighPStopTargKFFilter ]
    # # add sequences for upstream, calibration, ...  FIXME!
-   apr_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen, 
+   apr_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprHighPStopTargTCFilter, 
+      TTTZClusterFinder, aprHighPStopTargTCFilter,
       TTAprHelixFinder, TTAprHelixMerger, aprHighPStopTargHSFilter,
       TTAprKSF, aprHighPStopTargKSFilter, aprHighPStopTargTriggerInfoMerger ]
 
-   apr_lowP_stopTarg       : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   apr_lowP_stopTarg       : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger, 
+      TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprLowPStopTargHSFilter, TTAprKSF, aprLowPStopTargKSFilter, aprLowPStopTargTriggerInfoMerger ]
 
-   apr_lowP_stopTarg_multiTrk       : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   apr_lowP_stopTarg_multiTrk       : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargMultiTrkPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprLowPStopTargMultiTrkTCFilter, TTAprHelixFinder, TTAprHelixMerger, 
+      TTTZClusterFinder, aprLowPStopTargMultiTrkTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprLowPStopTargMultiTrkHSFilter, TTAprKSF, aprLowPStopTargMultiTrkKSFilter, aprLowPStopTargMultiTrkTriggerInfoMerger ]
 
-   apr_lowP_stopTarg_timing0       : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   apr_lowP_stopTarg_timing0       : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger, 
+      TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprLowPStopTargHSFilter, TTAprKSF ]
 
-   apr_lowP_stopTarg_timing1       : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   apr_lowP_stopTarg_timing1       : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger ]
 
-   apr_lowP_stopTarg_timing2       : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   apr_lowP_stopTarg_timing2       : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTTZClusterFinder ]
 
-   aprHelix          : [ @sequence::TrigRecoSequences.artFragmentsGen,  
+   aprHelix          : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprHelixTCFilter, TTAprHelixFinder, TTAprHelixMerger, 
+      TTTZClusterFinder, aprHelixTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprHelixHSFilter, aprHelixTriggerInfoMerger ]
 
 }

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -8,6 +8,14 @@
 
     "trigger_paths" : {
 
+        "mprDe_highP_stopTarg": {
+            "bit" : 101 ,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+        },
+
         "tprDe_highP_stopTarg": {
             "bit" : 100 ,
             "enabled": 1,
@@ -15,6 +23,7 @@
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
         },
+
         "tprDe_lowP_stopTarg" : {
             "bit": 110 ,
             "enabled": 1,
@@ -80,32 +89,32 @@
 
         "apr_highP_stopTarg"   : {
             "bit" : 180 ,
-            "enabled": 1, 
-            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] }, 
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
         },
-        
+
         "apr_lowP_stopTarg"   : {
             "bit" : 190 ,
-            "enabled": 1, 
-            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] }, 
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
         },
 
          "apr_lowP_stopTarg_multiTrk"   : {
             "bit" : 191 ,
-            "enabled": 1, 
-            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] }, 
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
         },
 
         "aprHelix"   : {
             "bit" : 195 ,
-            "enabled": 1, 
-            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] }, 
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
         },

--- a/test/triggerTestMC.fcl
+++ b/test/triggerTestMC.fcl
@@ -21,6 +21,12 @@ physics.producers.SelectRecoMCtprDe : {
   HelixSeedCollections  : ["TTHelixMergerDe" ]
 }
 
+physics.producers.SelectRecoMCapr : {
+  @table::CommonMCTrigger.TTSelectRecoMC
+  KalSeedCollections  : [ "TTAprKSF" ]
+  HelixSeedCollections  : ["TTAprHelixMerger" ]
+}
+
 physics.producers.SelectRecoMCmprDe : {
   @table::CommonMCTrigger.TTSelectRecoMC
   KalSeedCollections  : [ "TTMprKSFDe" ]
@@ -33,6 +39,7 @@ physics.producers.SelectRecoMCmprDe : {
 physics.tprDe_highP_stopTarg           : [ @sequence::physics.tprDe_highP_stopTarg, SelectRecoMCtprDe]
 physics.cprDe_highP_stopTarg           : [ @sequence::physics.cprDe_highP_stopTarg, SelectRecoMCcprDe]
 physics.mprDe_highP_stopTarg           : [ @sequence::physics.mprDe_highP_stopTarg, SelectRecoMCmprDe]
+physics.apr_highP_stopTarg             : [ @sequence::physics.apr_highP_stopTarg, SelectRecoMCapr]
 #
 # this next produces additional hit-level payload to support MC truth matching.
 # It produces functionally equivalent output as the standard module but is slower, so don't use this script for timing studies

--- a/test/triggerTestMC.fcl
+++ b/test/triggerTestMC.fcl
@@ -21,11 +21,18 @@ physics.producers.SelectRecoMCtprDe : {
   HelixSeedCollections  : ["TTHelixMergerDe" ]
 }
 
+physics.producers.SelectRecoMCmprDe : {
+  @table::CommonMCTrigger.TTSelectRecoMC
+  KalSeedCollections  : [ "TTMprKSFDe" ]
+  HelixSeedCollections  : ["TTMprHelixMergerDe" ]
+}
+
 #
 #  Add these to the sequences
 #
 physics.tprDe_highP_stopTarg           : [ @sequence::physics.tprDe_highP_stopTarg, SelectRecoMCtprDe]
 physics.cprDe_highP_stopTarg           : [ @sequence::physics.cprDe_highP_stopTarg, SelectRecoMCcprDe]
+physics.mprDe_highP_stopTarg           : [ @sequence::physics.mprDe_highP_stopTarg, SelectRecoMCmprDe]
 #
 # this next produces additional hit-level payload to support MC truth matching.
 # It produces functionally equivalent output as the standard module but is slower, so don't use this script for timing studies

--- a/test/triggerTestMC.fcl
+++ b/test/triggerTestMC.fcl
@@ -21,7 +21,7 @@ physics.producers.SelectRecoMCtprDe : {
   HelixSeedCollections  : ["TTHelixMergerDe" ]
 }
 
-physics.producers.SelectRecoMCapr : {
+physics.producers.SelectRecoMCaprDe : {
   @table::CommonMCTrigger.TTSelectRecoMC
   KalSeedCollections  : [ "TTAprKSF" ]
   HelixSeedCollections  : ["TTAprHelixMerger" ]
@@ -39,7 +39,7 @@ physics.producers.SelectRecoMCmprDe : {
 physics.tprDe_highP_stopTarg           : [ @sequence::physics.tprDe_highP_stopTarg, SelectRecoMCtprDe]
 physics.cprDe_highP_stopTarg           : [ @sequence::physics.cprDe_highP_stopTarg, SelectRecoMCcprDe]
 physics.mprDe_highP_stopTarg           : [ @sequence::physics.mprDe_highP_stopTarg, SelectRecoMCmprDe]
-physics.apr_highP_stopTarg             : [ @sequence::physics.apr_highP_stopTarg, SelectRecoMCapr]
+physics.apr_highP_stopTarg             : [ @sequence::physics.apr_highP_stopTarg, SelectRecoMCaprDe]
 #
 # this next produces additional hit-level payload to support MC truth matching.
 # It produces functionally equivalent output as the standard module but is slower, so don't use this script for timing studies


### PR DESCRIPTION
This PR adds a trigger line for RobustMultiHelixFinder (MPR).  That currently is splitting the output into dem and dep collections, once that code has been updated to produce a single output collection this will need some maintenance.  In the meantime it can be used for testing.