### PR TITLE
include default SimpleTimeCluster configuration

### DIFF
--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -774,6 +774,17 @@ TrigCstProducers : {
       ComboHitCollection: "TTmakePH"
       TestFlag: false
       module_type: "SimpleTimeCluster"
+      HitSelectionBits  : ["EnergySelection"]
+      HitBackgroundBits : ["Background","Noisy","Dead"]
+      debugLevel : 0
+      minNStrawHits : 2
+      minNPanels : 1
+      TimeWindow : 100
+      useTimeWindow : false
+      TimeStep : 20
+      useTimeStep : true
+      UseOnlyOnePanel : false
+      UseOnlyOnePlane : false
    }
 
    cstTimeClusterTriggerInfoMerger: {

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -7,7 +7,6 @@
 #include "Offline/TrkReco/fcl/prolog.fcl"
 #include "Offline/TrkPatRec/fcl/prolog.fcl"
 #include "Offline/CalPatRec/fcl/prolog.fcl"
-#include "Offline/CosmicReco/fcl/prolog.fcl"
 
 BEGIN_PROLOG
 
@@ -772,9 +771,20 @@ TrigCstProducers : {
       t0offset: 0
    }
    CstSimpleTimeCluster: {
-      @table::SimpleTimeCluster
       ComboHitCollection: "TTmakePH"
       TestFlag: false
+      module_type: "SimpleTimeCluster"
+      HitSelectionBits  : ["EnergySelection"]
+      HitBackgroundBits : ["Background","Noisy","Dead"]
+      debugLevel : 0
+      minNStrawHits : 2
+      minNPanels : 1
+      TimeWindow : 100
+      useTimeWindow : false
+      TimeStep : 20
+      useTimeStep : true
+      UseOnlyOnePanel : false
+      UseOnlyOnePlane : false
    }
 
    cstTimeClusterTriggerInfoMerger: {

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -7,6 +7,7 @@
 #include "Offline/TrkReco/fcl/prolog.fcl"
 #include "Offline/TrkPatRec/fcl/prolog.fcl"
 #include "Offline/CalPatRec/fcl/prolog.fcl"
+#include "Offline/CosmicReco/fcl/prolog.fcl"
 
 BEGIN_PROLOG
 
@@ -771,20 +772,9 @@ TrigCstProducers : {
       t0offset: 0
    }
    CstSimpleTimeCluster: {
+      @table::SimpleTimeCluster
       ComboHitCollection: "TTmakePH"
       TestFlag: false
-      module_type: "SimpleTimeCluster"
-      HitSelectionBits  : ["EnergySelection"]
-      HitBackgroundBits : ["Background","Noisy","Dead"]
-      debugLevel : 0
-      minNStrawHits : 2
-      minNPanels : 1
-      TimeWindow : 100
-      useTimeWindow : false
-      TimeStep : 20
-      useTimeStep : true
-      UseOnlyOnePanel : false
-      UseOnlyOnePlane : false
    }
 
    cstTimeClusterTriggerInfoMerger: {


### PR DESCRIPTION
Offline PR #1275 removes default `SimpleTimeCluster` configuration from source code, and hence requires full configuration in fcl. This PR accounts for the remaining configuration in the `SimpleTimeCluster` defined here, which then propagates to validation jobs.