### PR TITLE
Implementation of new cuts added to HelixFinders and new cpr and apr trig sequences

### DIFF
--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -34,6 +34,7 @@ TrigCprFilters:{
       debugLevel: 0
       debugLevel2: 0
       dfdzErr: 1e-1
+      maxNHitsRatio: 500
       diagLevel: 0
       distPatRec: 100
       dzOverHelPitchCut: 7e-1
@@ -47,6 +48,7 @@ TrigCprFilters:{
       maxPanelToHelixDPhi: 1.309
       maxXDPhi: 5
       maxZTripletSearch: 0
+      bz: 0.0
       minAbsTanDip: 3e-1
       minArea: 5000
       minDeltaNShPatRec: 2
@@ -58,7 +60,7 @@ TrigCprFilters:{
       nHitsMaxPerPanel: 1
       plotall: false
       sigmaPhi: 1.636e-1
-      smartTag: 1
+      # smartTag: 1
       targetconsistent: 0
       usetarget: true
       weight3D: 1.2e-1
@@ -68,7 +70,7 @@ TrigCprFilters:{
       zWeights: false
     }
     StrawHitCollectionLabel: "TTflagBkgHits"
-    StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
+    # StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
     TimeClusterCollectionLabel: "TTCalTimePeakFinder"
     debugLevel: 0
     diagLevel: 0
@@ -77,12 +79,18 @@ TrigCprFilters:{
       mcUtils: {
         strawDigiMCCollTag: "compressDigiMCs"
         tool_type: "TrkPatRecMcUtils"
+        comboHitCollTag: "makeSH"
       }
       tool_type: "CalHelixFinderDiag"
     }
+    Helicities: [
+      -1,
+      1
+    ]
     fitdirection: 0
     fitparticle: 11
     doSingleOutput: true
+    maxEDepAvg: 1
     minNHitsTimeCluster: 10
     module_type: "CalHelixFinder"
     printFrequency: 100
@@ -104,6 +112,7 @@ TrigCprFilters:{
       debugLevel: 0
       debugLevel2: 0
       dfdzErr: 1e-1
+      maxNHitsRatio: 500
       diagLevel: 0
       distPatRec: 100
       dzOverHelPitchCut: 7e-1
@@ -117,6 +126,7 @@ TrigCprFilters:{
       maxPanelToHelixDPhi: 1.309
       maxXDPhi: 5
       maxZTripletSearch: 0
+      bz: 0.0
       minAbsTanDip: 3e-1
       minArea: 5000
       minDeltaNShPatRec: 2
@@ -128,7 +138,7 @@ TrigCprFilters:{
       nHitsMaxPerPanel: 1
       plotall: false
       sigmaPhi: 1.636e-1
-      smartTag: 1
+      # smartTag: 1
       targetconsistent: 0
       usetarget: true
       weight3D: 1.2e-1
@@ -138,7 +148,7 @@ TrigCprFilters:{
       zWeights: false
     }
     StrawHitCollectionLabel: "TTflagBkgHits"
-    StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
+    # StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
     TimeClusterCollectionLabel: "TTCalTimePeakFinderUe"
     debugLevel: 0
     diagLevel: 0
@@ -147,12 +157,18 @@ TrigCprFilters:{
       mcUtils: {
         strawDigiMCCollTag: "compressDigiMCs"
         tool_type: "TrkPatRecMcUtils"
+        comboHitCollTag: "makeSH"
       }
       tool_type: "CalHelixFinderDiag"
     }
+    Helicities: [
+      -1,
+      1
+    ]
     fitdirection: 0
     fitparticle: 11
     doSingleOutput: true
+    maxEDepAvg: 1
     minNHitsTimeCluster: 10
     module_type: "CalHelixFinder"
     printFrequency: 100
@@ -987,19 +1003,19 @@ TrigAprFilters:{
     helixSeedCollection: "TTAprHelixMerger"
     posHelicitySelection : {
       configured: true
-      doHelicityCheck: true
+      doHelicityCheck: false
       maxAbsLambda: 300
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 300
-      maxMomentum: 2000
+      maxMomentum: 500
       maxNLoops: 30
       minAbsLambda: 140
       minD0: -150
       minHitRatio: 4e-1
-      minMomentum: 80
+      minMomentum: 70
       minNLoops: 0
-      minNStrawHits: 15
+      minNStrawHits: 12
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false
@@ -1011,14 +1027,14 @@ TrigAprFilters:{
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 300
-      maxMomentum: 2000
+      maxMomentum: 500
       maxNLoops: 30
       minAbsLambda: 140
       minD0: -150
       minHitRatio: 4e-1
       minMomentum: 70
       minNLoops: 0
-      minNStrawHits: 15
+      minNStrawHits: 12
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false
@@ -1036,13 +1052,13 @@ TrigAprFilters:{
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
-        doZPropDirCheck: true
+        doZPropDirCheck: false
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 200
         maxMomErr: 10
-        maxMomentum: 2000
+        maxMomentum: 500
         maxTanDip: 100
         minD0: -200
         minFitCons: -1
@@ -1054,13 +1070,13 @@ TrigAprFilters:{
       },
       {#cuts for downstreeam e-plus
         doParticleTypeCheck: false
-        doZPropDirCheck: true
+        doZPropDirCheck: false
         fitdirection: 0
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 200
         maxMomErr: 10
-        maxMomentum: 2000
+        maxMomentum: 500
         maxTanDip: 100
         minD0: -200
         minFitCons: -1
@@ -1172,11 +1188,11 @@ TrigAprFilters:{
     posHelicitySelection : {
       configured: true
       doHelicityCheck: true
-      maxAbsLambda: 500
+      maxAbsLambda: 1500
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 150
-      maxMomentum: 2000
+      maxMomentum: 500
       maxNLoops: 30
       minAbsLambda: 50
       minD0: -150
@@ -1191,16 +1207,16 @@ TrigAprFilters:{
     negHelicitySelection : {
       configured: true
       doHelicityCheck: true
-      maxAbsLambda: 500
+      maxAbsLambda: 1500
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 150
-      maxMomentum: 2000
+      maxMomentum: 500
       maxNLoops: 30
       minAbsLambda: 50
       minD0: -150
       minHitRatio: 4e-1
-      minMomentum: 70
+      minMomentum: 80
       minNLoops: 0
       minNStrawHits: 15
       minPt: 0
@@ -1221,13 +1237,13 @@ TrigAprFilters:{
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
-        doZPropDirCheck: true
+        doZPropDirCheck: false
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 150
         maxMomErr: 10
-        maxMomentum: 2000
+        maxMomentum: 500
         maxTanDip: 100
         minD0: -150
         minFitCons: -1
@@ -1239,13 +1255,13 @@ TrigAprFilters:{
       },
       { #cuts for downstreeam e-plus
         doParticleTypeCheck: false
-        doZPropDirCheck: true
+        doZPropDirCheck: false
         fitdirection: 0
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 150
         maxMomErr: 10
-        maxMomentum: 2000
+        maxMomentum:500
         maxTanDip: 100
         minD0: -150
         minFitCons: -1

--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -12,6 +12,8 @@ BEGIN_PROLOG
 TrigCprFilters:{
   cprDeHighPStopTargPS  : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
+  cprDeHighPPS          : { module_type: PrescaleEvent
+      eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   cprDeLowPStopTargPS   : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   cprHelixDePS          : { module_type: PrescaleEvent
@@ -34,7 +36,7 @@ TrigCprFilters:{
       debugLevel: 0
       debugLevel2: 0
       dfdzErr: 1e-1
-      maxNHitsRatio: 500
+      maxNHitsRatio: 1.5
       diagLevel: 0
       distPatRec: 100
       dzOverHelPitchCut: 7e-1
@@ -90,7 +92,7 @@ TrigCprFilters:{
     fitdirection: 0
     fitparticle: 11
     doSingleOutput: true
-    maxEDepAvg: 1
+    maxEDepAvg: 0.0025
     minNHitsTimeCluster: 10
     module_type: "CalHelixFinder"
     printFrequency: 100
@@ -112,7 +114,7 @@ TrigCprFilters:{
       debugLevel: 0
       debugLevel2: 0
       dfdzErr: 1e-1
-      maxNHitsRatio: 500
+      maxNHitsRatio: 1.5
       diagLevel: 0
       distPatRec: 100
       dzOverHelPitchCut: 7e-1
@@ -157,7 +159,7 @@ TrigCprFilters:{
       mcUtils: {
         strawDigiMCCollTag: "compressDigiMCs"
         tool_type: "TrkPatRecMcUtils"
-        comboHitCollTag: "makeSH"
+        comboHitCollTag: "TTmakeSH"
       }
       tool_type: "CalHelixFinderDiag"
     }
@@ -168,7 +170,7 @@ TrigCprFilters:{
     fitdirection: 0
     fitparticle: 11
     doSingleOutput: true
-    maxEDepAvg: 1
+    maxEDepAvg: 0.0025
     minNHitsTimeCluster: 10
     module_type: "CalHelixFinder"
     printFrequency: 100
@@ -317,6 +319,98 @@ TrigCprFilters:{
       }
     ]
   }
+
+  cprDeHighPHSFilter: {
+    module_type: "HelixFilter"
+    helixSeedCollection: "TTCalHelixMergerDe"
+    posHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 5
+      maxChi2XY: 5
+      maxD0: 600
+      maxMomentum: 500
+      maxNLoops: 30
+      minAbsLambda: 140
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 70
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+    negHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 5
+      maxChi2XY: 5
+      maxD0: 600
+      maxMomentum: 500
+      maxNLoops: 30
+      minAbsLambda: 100
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 60
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+  }
+  cprDeHighPTCFilter: {
+    minNStrawHits: 15
+    module_type: "TimeClusterFilter"
+    requireCaloCluster: true
+    timeClusterCollection: "TTCalTimePeakFinder"
+  }
+  cprDeHighPKSFilter: {
+    kalSeedCollection: "TTCalSeedFitDe"
+    module_type: "KalSeedFilter"
+    KalSeedCuts : [
+      { #cuts for downstreeam e-minus
+        fitdirection: 0
+        fitparticle: 11
+        doParticleTypeCheck: true
+        doZPropDirCheck: true
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 500
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 80
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      },
+      { #cuts for downstream e-plus
+        fitdirection: 0
+        fitparticle: -11
+        doParticleTypeCheck: true
+        doZPropDirCheck: true
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 500
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 70
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      }
+    ]
+  }
+
   cprDeLowPStopTargHSFilter: {
     helixSeedCollection: "TTCalHelixMergerDe"
     module_type: "HelixFilter"
@@ -995,6 +1089,8 @@ TrigAprFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   aprHighPStopTargPS       : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
+  aprHighPPS               : { module_type: PrescaleEvent
+      eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   aprLowPStopTargMultiTrkPS: { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
 
@@ -1003,19 +1099,19 @@ TrigAprFilters:{
     helixSeedCollection: "TTAprHelixMerger"
     posHelicitySelection : {
       configured: true
-      doHelicityCheck: false
+      doHelicityCheck: true
       maxAbsLambda: 300
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 300
-      maxMomentum: 500
+      maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 140
       minD0: -150
       minHitRatio: 4e-1
-      minMomentum: 70
+      minMomentum: 80
       minNLoops: 0
-      minNStrawHits: 12
+      minNStrawHits: 15
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false
@@ -1027,14 +1123,14 @@ TrigAprFilters:{
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 300
-      maxMomentum: 500
+      maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 140
       minD0: -150
       minHitRatio: 4e-1
       minMomentum: 70
       minNLoops: 0
-      minNStrawHits: 12
+      minNStrawHits: 15
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false
@@ -1052,13 +1148,13 @@ TrigAprFilters:{
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
-        doZPropDirCheck: false
+        doZPropDirCheck: true
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 200
         maxMomErr: 10
-        maxMomentum: 500
+        maxMomentum: 2000
         maxTanDip: 100
         minD0: -200
         minFitCons: -1
@@ -1070,15 +1166,106 @@ TrigAprFilters:{
       },
       {#cuts for downstreeam e-plus
         doParticleTypeCheck: false
-        doZPropDirCheck: false
+        doZPropDirCheck: true
         fitdirection: 0
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 200
         maxMomErr: 10
-        maxMomentum: 500
+        maxMomentum: 2000
         maxTanDip: 100
         minD0: -200
+        minFitCons: -1
+        minMomentum: 70
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      }
+    ]
+  }
+
+  aprHighPHSFilter: {
+    module_type: "HelixFilter"
+    helixSeedCollection: "TTAprHelixMerger"
+    posHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 140
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 80
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+    negHelicitySelection: {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 140
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 70
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+  }
+  aprHighPTCFilter : {
+    minNStrawHits: 15
+    module_type: "TimeClusterFilter"
+    requireCaloCluster: false
+    timeClusterCollection: "TTTZClusterFinder"
+  }
+  aprHighPKSFilter: {
+    kalSeedCollection: "TTAprKSF"
+    module_type: "KalSeedFilter"
+    KalSeedCuts : [
+      { #cuts for downstreeam e-minus
+        doParticleTypeCheck: false
+        doZPropDirCheck: true
+        fitdirection: 0
+        fitparticle: 11
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 2000
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 80
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      },
+      {#cuts for downstreeam e-plus
+        doParticleTypeCheck: false
+        doZPropDirCheck: true
+        fitdirection: 0
+        fitparticle: -11
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 2000
+        maxTanDip: 1000
+        minD0: -600
         minFitCons: -1
         minMomentum: 70
         minNStrawHits: 15
@@ -1188,11 +1375,11 @@ TrigAprFilters:{
     posHelicitySelection : {
       configured: true
       doHelicityCheck: true
-      maxAbsLambda: 1500
+      maxAbsLambda: 500
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 150
-      maxMomentum: 500
+      maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 50
       minD0: -150
@@ -1207,16 +1394,16 @@ TrigAprFilters:{
     negHelicitySelection : {
       configured: true
       doHelicityCheck: true
-      maxAbsLambda: 1500
+      maxAbsLambda: 500
       maxChi2PhiZ: 8
       maxChi2XY: 8
       maxD0: 150
-      maxMomentum: 500
+      maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 50
       minD0: -150
       minHitRatio: 4e-1
-      minMomentum: 80
+      minMomentum: 70
       minNLoops: 0
       minNStrawHits: 15
       minPt: 0
@@ -1237,13 +1424,13 @@ TrigAprFilters:{
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
-        doZPropDirCheck: false
+        doZPropDirCheck: true
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 150
         maxMomErr: 10
-        maxMomentum: 500
+        maxMomentum: 2000
         maxTanDip: 100
         minD0: -150
         minFitCons: -1
@@ -1255,13 +1442,13 @@ TrigAprFilters:{
       },
       { #cuts for downstreeam e-plus
         doParticleTypeCheck: false
-        doZPropDirCheck: false
+        doZPropDirCheck: true
         fitdirection: 0
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 150
         maxMomErr: 10
-        maxMomentum:500
+        maxMomentum:2000
         maxTanDip: 100
         minD0: -150
         minFitCons: -1

--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -78,7 +78,7 @@ TrigCprFilters:{
       mcUtils: {
         strawDigiMCCollTag: "compressDigiMCs"
         tool_type: "TrkPatRecMcUtils"
-        comboHitCollTag: "makeSH"
+        comboHitCollTag: "TTmakeSH"
       }
       tool_type: "CalHelixFinderDiag"
     }
@@ -326,7 +326,7 @@ TrigCprFilters:{
       maxD0: 600
       maxMomentum: 500
       maxNLoops: 30
-      minAbsLambda: 140
+      minAbsLambda: 50
       minD0: -600
       minHitRatio: 4e-1
       minMomentum: 70
@@ -345,7 +345,7 @@ TrigCprFilters:{
       maxD0: 600
       maxMomentum: 500
       maxNLoops: 30
-      minAbsLambda: 100
+      minAbsLambda: 50
       minD0: -600
       minHitRatio: 4e-1
       minMomentum: 60
@@ -608,6 +608,8 @@ TrigTprFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   tprDeHighPStopTargPS       : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
+  tprDeHighPPS               : { module_type: PrescaleEvent
+      eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   tprHelixDePS               : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   tprHelixUePS               : { module_type: PrescaleEvent
@@ -700,6 +702,99 @@ TrigTprFilters:{
         maxMomentum: 500
         maxTanDip: 100
         minD0: -200
+        minFitCons: -1
+        minMomentum: 70
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      }
+    ]
+  }
+
+  tprDeHighPHSFilter: {
+    module_type: "HelixFilter"
+    helixSeedCollection: "TTHelixMergerDe"
+    posHelicitySelection : {
+      configured: true
+      doHelicityCheck: false
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 500
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 70
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+    negHelicitySelection : {
+      configured: true
+      doHelicityCheck: false
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 500
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 60
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+  }
+
+  tprDeHighPTCFilter: {
+    minNStrawHits: 15
+    module_type: "TimeClusterFilter"
+    requireCaloCluster: false
+    timeClusterCollection: "TTtimeClusterFinder"
+  }
+
+  tprDeHighPKSFilter: {
+    module_type: "KalSeedFilter"
+    kalSeedCollection: "TTKSFDe"
+    KalSeedCuts : [
+      { #cuts for doesntream e-minus
+        fitdirection: 0
+        fitparticle: 11
+        doParticleTypeCheck: true
+        doZPropDirCheck: true
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 500
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 80
+        minNStrawHits: 15
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      },
+      {
+        fitdirection: 0
+        fitparticle: -11
+        doParticleTypeCheck: true
+        doZPropDirCheck: true
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 500
+        maxTanDip: 1000
+        minD0: -600
         minFitCons: -1
         minMomentum: 70
         minNStrawHits: 15
@@ -1191,7 +1286,7 @@ TrigAprFilters:{
       maxD0: 600
       maxMomentum: 2000
       maxNLoops: 30
-      minAbsLambda: 140
+      minAbsLambda: 50
       minD0: -600
       minHitRatio: 4e-1
       minMomentum: 80
@@ -1210,7 +1305,7 @@ TrigAprFilters:{
       maxD0: 600
       maxMomentum: 2000
       maxNLoops: 30
-      minAbsLambda: 140
+      minAbsLambda: 50
       minD0: -600
       minHitRatio: 4e-1
       minMomentum: 70

--- a/core/trigFilters.fcl
+++ b/core/trigFilters.fcl
@@ -50,7 +50,6 @@ TrigCprFilters:{
       maxPanelToHelixDPhi: 1.309
       maxXDPhi: 5
       maxZTripletSearch: 0
-      bz: 0.0
       minAbsTanDip: 3e-1
       minArea: 5000
       minDeltaNShPatRec: 2
@@ -62,7 +61,6 @@ TrigCprFilters:{
       nHitsMaxPerPanel: 1
       plotall: false
       sigmaPhi: 1.636e-1
-      # smartTag: 1
       targetconsistent: 0
       usetarget: true
       weight3D: 1.2e-1
@@ -72,7 +70,6 @@ TrigCprFilters:{
       zWeights: false
     }
     StrawHitCollectionLabel: "TTflagBkgHits"
-    # StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
     TimeClusterCollectionLabel: "TTCalTimePeakFinder"
     debugLevel: 0
     diagLevel: 0
@@ -128,7 +125,6 @@ TrigCprFilters:{
       maxPanelToHelixDPhi: 1.309
       maxXDPhi: 5
       maxZTripletSearch: 0
-      bz: 0.0
       minAbsTanDip: 3e-1
       minArea: 5000
       minDeltaNShPatRec: 2
@@ -140,7 +136,6 @@ TrigCprFilters:{
       nHitsMaxPerPanel: 1
       plotall: false
       sigmaPhi: 1.636e-1
-      # smartTag: 1
       targetconsistent: 0
       usetarget: true
       weight3D: 1.2e-1
@@ -150,7 +145,6 @@ TrigCprFilters:{
       zWeights: false
     }
     StrawHitCollectionLabel: "TTflagBkgHits"
-    # StrawHitFlagCollectionLabel: "DeltaFinder:ComboHits"
     TimeClusterCollectionLabel: "TTCalTimePeakFinderUe"
     debugLevel: 0
     diagLevel: 0

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -387,7 +387,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinder"
     UpdateStereo: false
-    maxEDepAvg: 2.5
+    maxEDepAvg: 0.0025
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -567,7 +567,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinderUe"
     UpdateStereo: false
-    maxEDepAvg: 2.5
+    maxEDepAvg: 0.0025
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -645,6 +645,9 @@ TrigCprProducers : {
   cprDeHighPStopTargTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
+  cprDeHighPTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
   cprDeLowPStopTargTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
@@ -670,7 +673,8 @@ TrigAprProducers : {
     tcCollLabel             : "TTTZClusterFinder"
     ccCollLabel             : "CaloClusterFast"
     minNHelixComboHits      : 10
-    maxEDepAvg              : 2.5
+    maxEDepAvg              : 0.0025
+    maxNHitsRatio           : 1.5
   }
 
   TTAprHelixMerger: {
@@ -702,6 +706,9 @@ TrigAprProducers : {
   }
 
   aprHighPStopTargTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
+  aprHighPTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
   aprLowPStopTargTriggerInfoMerger: {

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -165,6 +165,11 @@ TrigTrkProducers : {
     sschCollTag                   : TTmakeSH                # input coll
     writeFilteredComboHits        : 1
   }
+
+  TTHelixFinderParams: {
+    @table::TrkHitReco.HelixFinderParams
+    maxEDepAvg : 0.0025
+  }
 }
 
 ################################################################################
@@ -387,7 +392,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinder"
     UpdateStereo: false
-    maxEDepAvg: 0.0025
+    maxEDepAvg: @local::TrigTrkProducers.TTHelixFinderParams.maxEDepAvg
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -567,7 +572,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinderUe"
     UpdateStereo: false
-    maxEDepAvg: 0.0025
+    maxEDepAvg: @local::TrigTrkProducers.TTHelixFinderParams.maxEDepAvg
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -577,6 +582,9 @@ TrigTprProducers : {
   }
 
   tprDeHighPStopTargTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
+  tprDeHighPTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
   tprDeLowPStopTargTriggerInfoMerger: {
@@ -673,7 +681,7 @@ TrigAprProducers : {
     tcCollLabel             : "TTTZClusterFinder"
     ccCollLabel             : "CaloClusterFast"
     minNHelixComboHits      : 10
-    maxEDepAvg              : 0.0025
+    maxEDepAvg              : @local::TrigTrkProducers.TTHelixFinderParams.maxEDepAvg
     maxNHitsRatio           : 1.5
   }
 
@@ -754,6 +762,7 @@ TrigMprProducers : {
     MinStrawHits            : 10
     NMaxTrkIter             : 3
     DiagLevel               : 0
+    maxEDepAvg              : @local::TrigTrkProducers.TTHelixFinderParams.maxEDepAvg
   }
   TTMprHelixMergerDe: {
     HelixFinders: [ "TTRobustMultiHelixFinder:Positive", "TTRobustMultiHelixFinder:Negative" ]

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -387,6 +387,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinder"
     UpdateStereo: false
+    maxEDepAvg: 2.5
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -566,6 +567,7 @@ TrigTprProducers : {
     }
     TimeClusterCollection: "TTtimeClusterFinderUe"
     UpdateStereo: false
+    maxEDepAvg: 2.5
     UpdateStereoHits: false
     UseHitMVA: false
     UseTripletArea: false
@@ -668,6 +670,7 @@ TrigAprProducers : {
     tcCollLabel             : "TTTZClusterFinder"
     ccCollLabel             : "CaloClusterFast"
     minNHelixComboHits      : 10
+    maxEDepAvg              : 2.5
   }
 
   TTAprHelixMerger: {

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -167,7 +167,7 @@ TrigTrkProducers : {
   }
 
   TTHelixFinderParams: {
-    @table::TrkHitReco.HelixFinderParams
+    @table::TrkReco.HelixFinderParams
     maxEDepAvg : 0.0025
   }
 }

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -66,7 +66,12 @@ TrigTrkPaths:{
    cprDe_highP_stopTarg           : [ @sequence::TrigRecoSequences.artFragmentsGen,  cprDeHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTCalTimePeakFinder, cprDeHighPStopTargTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDe, cprDeHighPStopTargHSFilter,
-      TTCalSeedFitDe, cprDeHighPStopTargKSFilter, cprDeHighPStopTargTriggerInfoMerger ]
+    TTCalSeedFitDe, cprDeHighPStopTargKSFilter, cprDeHighPStopTargTriggerInfoMerger ]
+  
+  cprDe_highP               : [ @sequence::TrigRecoSequences.artFragmentsGen,  cprDeHighPPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTCalTimePeakFinder, cprDeHighPTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDe, cprDeHighPHSFilter,
+      TTCalSeedFitDe, cprDeHighPKSFilter, cprDeHighPTriggerInfoMerger ]
 
    cprDe_lowP_stopTarg       : [ @sequence::TrigRecoSequences.artFragmentsGen,  cprDeLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
@@ -156,6 +161,13 @@ TrigTrkPaths:{
       TTTZClusterFinder, aprHighPStopTargTCFilter,
       TTAprHelixFinder, TTAprHelixMerger, aprHighPStopTargHSFilter,
       TTAprKSF, aprHighPStopTargKSFilter, aprHighPStopTargTriggerInfoMerger ]
+
+  apr_highP                     : [ @sequence::TrigRecoSequences.artFragmentsGen,
+      aprHighPPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTTZClusterFinder, aprHighPTCFilter,
+      TTAprHelixFinder, TTAprHelixMerger, aprHighPHSFilter,
+      TTAprKSF, aprHighPKSFilter, aprHighPTriggerInfoMerger ]
 
    apr_highP_stopTarg_timing0   : [ @sequence::TrigRecoSequences.artFragmentsGen,
       aprHighPStopTargPS, @sequence::TrigRecoSequences.calReco,

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -32,6 +32,10 @@ TrigTrkPaths:{
       tprDeHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTtimeClusterFinder, tprDeHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDe, tprDeHighPStopTargHSFilter, TTKSFDe, tprDeHighPStopTargKSFilter, tprDeHighPStopTargTriggerInfoMerger ]
+   tprDe_highP           : [ @sequence::TrigRecoSequences.artFragmentsGen,
+      tprDeHighPPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTtimeClusterFinder, tprDeHighPTCFilter, TThelixFinder, TTHelixMergerDe, tprDeHighPHSFilter, TTKSFDe, tprDeHighPKSFilter, tprDeHighPTriggerInfoMerger ]
    tprDe               : [ tprDeHighPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTtimeClusterFinder, tprDeHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDe, tprDeHighPStopTargHSFilter, TTKSFDe, tprDeHighPStopTargKSFilter, tprDeHighPStopTargTriggerInfoMerger ]

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -24,6 +24,14 @@
                                ]
         },
 
+        "tprDe_highP"         : {
+            "bit" : 101 ,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+        },
+
         "tprDe_lowP_stopTarg" : {
             "bit": 110 ,
             "enabled": 1,

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -66,6 +66,13 @@
                                  {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }]
         },
 
+        "cprDe_highP": {
+            "bit" : 151 ,
+            "enabled": 1,
+            "eventModeConfig" : [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ]},
+                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }]
+        },
+
         "cprDe_lowP_stopTarg" : {
             "bit" : 160,
             "enabled": 1,
@@ -89,6 +96,14 @@
 
         "apr_highP_stopTarg"   : {
             "bit" : 180 ,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+        },
+
+        "apr_highP"   : {
+            "bit" : 181 ,
             "enabled": 1,
             "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -24,13 +24,13 @@
                                ]
         },
 
-        "tprDe_highP"         : {
+        /*"tprDe_highP"         : {
             "bit" : 101 ,
             "enabled": 1,
             "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
-        },
+        },*/
 
         "tprDe_lowP_stopTarg" : {
             "bit": 110 ,
@@ -74,12 +74,12 @@
                                  {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }]
         },
 
-        "cprDe_highP": {
+        /*"cprDe_highP": {
             "bit" : 151 ,
             "enabled": 1,
             "eventModeConfig" : [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ]},
                                  {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }]
-        },
+        },*/
 
         "cprDe_lowP_stopTarg" : {
             "bit" : 160,
@@ -110,13 +110,13 @@
                                ]
         },
 
-        "apr_highP"   : {
+        /*"apr_highP"   : {
             "bit" : 181 ,
             "enabled": 1,
             "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
                                ]
-        },
+        },*/
 
         "apr_lowP_stopTarg"   : {
             "bit" : 190 ,


### PR DESCRIPTION
- Added maxEDepAvg and maxNHitsRatio to corresponding filter/producers, in correspondence with Offline PR: [https://github.com/Mu2e/Offline/pull/1289](url)
- Added cprDeHighP and aprHighP trigger sequences which have looser constraints on impact parameter, lambda, and tanDip