### PR TITLE
fixed setting of one apr support trigger + update the config interface for CalTimePeakFinder

### DIFF
--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -294,11 +294,11 @@ TrigAprFilters:{
       maxAbsLambda: 500
       maxChi2PhiZ: 8
       maxChi2XY: 8
-      maxD0: 150
+      maxD0: 600. #150
       maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 50
-      minD0: -150
+      minD0: -600. #-150
       minHitRatio: 4e-1
       minMomentum: 80
       minNLoops: 0
@@ -344,11 +344,11 @@ TrigAprFilters:{
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
-        maxD0: 150
+        maxD0: 600. #150
         maxMomErr: 10
         maxMomentum: 2000
         maxTanDip: 100
-        minD0: -150
+        minD0: -600.   #-150
         minFitCons: -1
         minMomentum: 80
         minNStrawHits: 12
@@ -362,11 +362,11 @@ TrigAprFilters:{
         fitdirection: 0
         fitparticle: -11
         maxChi2DOF: 20
-        maxD0: 150
+        maxD0: 600 #150
         maxMomErr: 10
         maxMomentum:2000
         maxTanDip: 100
-        minD0: -150
+        minD0: -600. #-150
         minFitCons: -1
         minMomentum: 80
         minNStrawHits: 12

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -294,7 +294,7 @@ TrigAprFilters:{
       maxAbsLambda: 500
       maxChi2PhiZ: 8
       maxChi2XY: 8
-      maxD0: 600. #150
+      maxD0: 600. 
       maxMomentum: 2000
       maxNLoops: 30
       minAbsLambda: 50
@@ -344,7 +344,7 @@ TrigAprFilters:{
         fitdirection: 0
         fitparticle: 11
         maxChi2DOF: 20
-        maxD0: 600. #150
+        maxD0: 600.
         maxMomErr: 10
         maxMomentum: 2000
         maxTanDip: 100

--- a/core/filters/trigCalFilters.fcl
+++ b/core/filters/trigCalFilters.fcl
@@ -9,7 +9,7 @@ TrigCalFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   caloFastRMCPS       : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
-  caloHitRecN0SourceFilter : { module_type: PrescaleEvent
+  caloHitRecN0SourcePS : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
       
   caloFastCosmicFilter: {

--- a/core/producers/trigCprProducers.fcl
+++ b/core/producers/trigCprProducers.fcl
@@ -151,54 +151,58 @@ TrigCprProducers : {
    }
 
    TTCalTimePeakFinder: {
+      HitSelBits: ["TimeSelection","EnergySelection"]
+      BkgSelBits: [
+         "Background",
+         "Noisy",
+         "Dead"
+      ]
       DtMax: 20
       DtMin: -20
       MinNHits: 10
       StrawHitCollectionLabel: "TTflagBkgHits"
-      StrawHitFlagCollectionLabel: "ShouldNotBeUsed"
-      beta: 1
-      caloClusterModuleLabel: "CaloClusterFast"
-      debugLevel: 0
-      diagLevel: 0
-      diagPlugin: {
+      Beta: 1
+      CaloClusterModuleLabel: "CaloClusterFast"
+      DebugLevel: 0
+      DiagLevel: 0
+      DiagPlugin: {
          mcTruth: 0
-         mcUtils: {
-            strawDigiMCCollTag: "compressDigiMCs"
-            tool_type: "TrkPatRecMcUtils"
-         }
+         diagLevel: 0
          tool_type: "CalTimePeakFinderDiag"
       }
-      dtOffset: 0
-      minClusterEnergy: 50
-      minClusterSize: 2
+      DtOffset: 0
+      MinClusterEnergy: 50
+      MinClusterSize: 2
       module_type: "CalTimePeakFinder"
-      pitchAngle: 6.7e-1
-      printFrequency: 100
+      PitchAngle: 6.7e-1
+      PrintFrequency: 100
    }
    TTCalTimePeakFinderUe: {
+      HitSelBits: ["TimeSelection","EnergySelection"]
+      BkgSelBits: [
+         "Background",
+         "Noisy",
+         "Dead"
+      ]
       DtMax: 20
       DtMin: -20
       MinNHits: 10
       StrawHitCollectionLabel: "TTflagBkgHits"
-      StrawHitFlagCollectionLabel: "ShouldNotBeUsed"
-      beta: 1
-      caloClusterModuleLabel: "CaloClusterFast"
-      debugLevel: 0
-      diagLevel: 0
-      diagPlugin: {
+      Beta: 1
+      CaloClusterModuleLabel: "CaloClusterFast"
+      DebugLevel: 0
+      DiagLevel: 0
+      DiagPlugin: {
+         diagLevel: 0
          mcTruth: 0
-         mcUtils: {
-            strawDigiMCCollTag: "compressDigiMCs"
-            tool_type: "TrkPatRecMcUtils"
-         }
          tool_type: "CalTimePeakFinderDiag"
       }
-      dtOffset: -3.1
-      minClusterEnergy: 50
-      minClusterSize: 2
+      DtOffset: -3.1
+      MinClusterEnergy: 50
+      MinClusterSize: 2
       module_type: "CalTimePeakFinder"
-      pitchAngle: -6.7e-1
-      printFrequency: 100
+      PitchAngle: -6.7e-1
+      PrintFrequency: 100
    }
 
    TTCalHelixMergerDe: {

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -202,7 +202,7 @@
         "caloHitRec_N0Source":{
             "bit" : 500 ,
             "enabled": 1,
-            "eventModeConfig" : [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_calo_calib" ]},
+            "eventModeConfig" : [{"eventMode":"OnSpill", "prescale":10000, "streams": [ "physics_calo_calib" ]},
                                  {"eventMode":"OffSpill", "prescale":10000, "streams": [ "cosmics_main", "physics_calo_calib" ]}] 
        }
 


### PR DESCRIPTION
- the change in the CalTimePeakFinder interface impacts nowhere in the trigger results because we are already processing a filtered list of hits
- fixed d0 interval in a support trigger