### PR TITLE
Trigger CI starting point

### DIFF
--- a/ci/check_trigger_results.py
+++ b/ci/check_trigger_results.py
@@ -1,0 +1,107 @@
+# Compare two trigger reports
+
+import sys
+
+#--------------------------------------------------------------
+# Fill the log results
+def fill_results(f, verbose = 0):
+    results = {}
+
+    timing_info = []
+    for line in f:
+        if verbose > 1: print(line)
+        # Exit once the trigger path summary has completed
+        if 'End-path summary' in line: break
+        words = line.split()
+        # Check if it's the timing information
+        if len(words) == 8 and words[0] == "Full" and words[1] == "event":
+            #             [min, avg, max, median, rms]
+            timing_info = [float(words[index]) for index in range(2,7)]
+            if verbose > 0:
+                print("Timing info:    min        avg        max       median     rms")
+                print("             %.3e  %.3e  %.3e  %.3e  %.3e" % (timing_info[0], timing_info[1], timing_info[2],
+                                                               timing_info[3], timing_info[3]))
+                print("Path                          :    run   pass   fail  error")
+            continue
+        # Check if it's a trigger path summary line
+        if len(words) != 7 or words[0] != 'TrigReport': continue
+        try:
+            #        [run, pass, fail, error]
+            counts = [int(words[index]) for index in range(2,6)]
+            path   = words[-1]
+            results[path] = counts
+            if verbose > 0:
+                print("%30s: %6i %6i %6i %6i" % (path, counts[0], counts[1], counts[2], counts[3]))
+        except: continue
+    return results,timing_info
+
+#--------------------------------------------------------------
+# Main execution
+if len(sys.argv) < 3:
+    print("Not enough arguments! Useage: python check_trigger_results.py <file_1> <file_2> [verbose level, default = 0]")
+    exit(2)
+verbose = int(sys.argv[3]) if len(sys.argv) == 4 else 0
+
+file_1 = sys.argv[1] # Local log file
+file_2 = sys.argv[2] # Reference log file
+try:
+    f_1 = open(file_1,'r')
+    f_2 = open(file_2,'r')
+except FileNotFoundError:
+    print("Files were not both found!")
+    exit(2)
+
+if verbose > 0: print(">>> Retrieving info from the local processing")
+results_1,timing_1 = fill_results(f_1, verbose)
+if verbose > 0: print(">>> Retrieving info from the reference processing")
+results_2,timing_2 = fill_results(f_2, verbose)
+
+# Define the major vs. minor failure thresholds
+count_minor_threshold = 1 # path rate change for minor failure
+count_major_threshold = 4 # path rate change for major failure
+avg_time_minor_threshold = 0.15 # fractional change in time / event
+avg_time_major_threshold = 0.25 # fractional change in time / event
+minor_fail = False
+major_fail = False
+
+# Check the path rates
+for path in results_1:
+    if path in results_2:
+        counts_1 = results_1[path]
+        counts_2 = results_2[path]
+        for index in range(len(counts_1)):
+            delta = abs(counts_1[index] - counts_2[index])
+            if delta >= count_major_threshold:
+                major_fail = True
+                print(">>> Path " + path + " has a major change!")
+                print("Local counts    :", counts_1)
+                print("Reference counts:", counts_2)
+            elif delta >= count_minor_threshold:
+                minor_fail = True
+                print(">>> Path " + path + " has a minor change:")
+                print("Local counts    :", counts_1)
+                print("Reference counts:", counts_2)
+    else:
+        print(">>> New trigger path " + path + " in local found, not in the reference!")
+        major_fail = True
+for path in results_2:
+    if path not in results_1:
+        print(">>> Trigger path " + path + " in reference not found in local!")
+        major_fail = True
+
+# Check the timing rates
+avg_time_delta = abs(timing_1[1]/timing_2[1] - 1.)
+if avg_time_delta > avg_time_major_threshold:
+    print(">>> Average time changed significantly: %.4f (new) vs. %.4f (reference)" % (timing_2[1], timing_1[1]))
+    major_fail = True
+elif avg_time_delta > avg_time_minor_threshold:
+    print(">>> Average time changed somewhat significantly: %.4f (new) vs. %.4f (reference)" % (timing_2[1], timing_1[1]))
+    minor_fail = True
+
+# Return the exit codes for minor/major failures
+if major_fail: exit(2)
+if minor_fail: exit(1)
+
+# No failures
+print("No problems detected")
+exit(0)

--- a/ci/check_trigger_results.sh
+++ b/ci/check_trigger_results.sh
@@ -2,12 +2,17 @@
 # Compare a local trigger log to a reference log file
 
 # Process the example data-like digi file
-NEVENTS=1000
+NEVENTS=-1
 DATAFILE="mu2e_trig_config/ci/data_files.txt"
 LOGFILE="local_trigger_results.log"
 REFERENCE="mu2e_trig_config/ci/reference_log_file.log"
 mu2e -c mu2e_trig_config/test/triggerTest.fcl -S ${DATAFILE} -n ${NEVENTS} >| ${LOGFILE}
 STATUS=$?
+
+# Add the log to the stdout report
+cat ${LOGFILE}
+
+# Check if the processing failed
 if [ $STATUS -ne 0 ]; then
     echo ">>> Failed to process triggerTest.fcl"
     exit 2

--- a/ci/check_trigger_results.sh
+++ b/ci/check_trigger_results.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+# Compare a local trigger log to a reference log file
+
+# Process the example data-like digi file
+NEVENTS=1000
+DATAFILE="mu2e_trig_config/ci/data_files.txt"
+LOGFILE="local_trigger_results.log"
+REFERENCE="mu2e_trig_config/ci/reference_log_file.log"
+mu2e -c mu2e_trig_config/test/triggerTest.fcl -S ${DATAFILE} -n ${NEVENTS} >| ${LOGFILE}
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+    echo ">>> Failed to process triggerTest.fcl"
+    exit 2
+fi
+
+# Compare the log file to an example log file
+python mu2e_trig_config/ci/check_trigger_results.py ${LOGFILE} ${REFERENCE}
+STATUS=$?
+exit $STATUS

--- a/ci/data_files.txt
+++ b/ci/data_files.txt
@@ -1,0 +1,2 @@
+/exp/mu2e/data/users/mmackenz/data/skim_NoPrimary1BB_1a.art
+/exp/mu2e/data/users/mmackenz/data/skim_NoPrimary1BB_1b.art

--- a/ci/data_files.txt
+++ b/ci/data_files.txt
@@ -1,2 +1,2 @@
-/exp/mu2e/data/users/mmackenz/data/skim_NoPrimary1BB_1a.art
-/exp/mu2e/data/users/mmackenz/data/skim_NoPrimary1BB_1b.art
+/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art
+/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art

--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,7 +1,7 @@
    ************************** Mu2e Offline **************************
      art v3_14_03    root v6_30_04    KinKal v03_01_05
      build  /exp/mu2e/app/users/mmackenz/Yale/main
-     build  al9-prof-e28-p066    01/03/25 12:53:22
+     build  al9-prof-e28-p066    01/07/25 17:33:49
    ******************************************************************
 Conditions file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/ConditionsService/data/conditions_01.txt
 Conditions lines: 38  hash: 8098310628555253397
@@ -14,16 +14,16 @@ BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing (
 DeltaFinderAlg created
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
-06-Jan-2025 16:14:59 CST  Initiating request to open input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
-06-Jan-2025 16:14:59 CST  Opened input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
+08-Jan-2025 11:08:47 CST  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+08-Jan-2025 11:08:47 CST  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
 tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 Geometry file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/geom_common.txt
 Geometry lines: 20795  hash: 8400552694993792382
 BField file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
 BField lines: 98  hash: 3243269116804334601
-Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 06-Jan-2025 16:14:59 CST
-DbReader::fillValCache took 0.323606 s
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 08-Jan-2025 11:09:09 CST
+DbReader::fillValCache took 0.205437 s
 DbEngine confirmed purpose and version:
 MDC2020_best 1/3/-1
 DbEngine IoV summary
@@ -48,146 +48,168 @@ DbEngine IoV summary
              CRVSiPM       3
            CRVPhoton       3
              CRVTime       3
-DbEngine inclusive beginJob time was 0.323854 s
-Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 06-Jan-2025 16:15:00 CST
-Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 06-Jan-2025 16:15:00 CST
-Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 06-Jan-2025 16:15:00 CST
-Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 06-Jan-2025 16:15:00 CST
-Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 06-Jan-2025 16:15:01 CST
-Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 06-Jan-2025 16:15:01 CST
-Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 06-Jan-2025 16:15:02 CST
-Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 06-Jan-2025 16:15:02 CST
-Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 06-Jan-2025 16:15:04 CST
-Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 06-Jan-2025 16:15:09 CST
-06-Jan-2025 16:15:17 CST  Closed input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
+DbEngine inclusive beginJob time was 0.205779 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 08-Jan-2025 11:09:10 CST
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 08-Jan-2025 11:09:10 CST
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 08-Jan-2025 11:09:10 CST
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 08-Jan-2025 11:09:10 CST
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 08-Jan-2025 11:09:10 CST
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 08-Jan-2025 11:09:10 CST
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 08-Jan-2025 11:09:11 CST
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 08-Jan-2025 11:09:11 CST
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 08-Jan-2025 11:09:14 CST
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 08-Jan-2025 11:09:18 CST
+Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 08-Jan-2025 11:09:27 CST
+Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 08-Jan-2025 11:09:44 CST
+Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 08-Jan-2025 11:10:18 CST
+Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 08-Jan-2025 11:11:29 CST
+08-Jan-2025 11:12:00 CST  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+08-Jan-2025 11:12:00 CST  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+08-Jan-2025 11:12:00 CST  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+%MSG-w GEOM:  BeginRun 08-Jan-2025 11:12:00 CST run: 1202
+This test version does not change geometry on run boundaries.
+%MSG
+This test version does not change geometry on run boundaries.
+Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 08-Jan-2025 11:13:47 CST
+08-Jan-2025 11:14:49 CST  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
 
 =======================================================================================================================================================================
 TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
 =======================================================================================================================================================================
-Full event                                                                           0.00110845     0.0173603     0.907858      0.0088097     0.0353873      1000    
+Full event                                                                           0.000944837    0.0168529      0.90171     0.00894537     0.0227861      20000   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-source:RootInput(read)                                                               6.5605e-05    0.000108049   0.000427868   9.7265e-05    3.87906e-05     1000    
-caloHitRec_N0Source:artFragFromDTCEvents:ArtFragmentsFromDTCEvents                   1.0761e-05    1.42928e-05   0.000184151   1.2563e-05    7.23129e-06     1000    
-caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.777e-06    1.28268e-05   0.000288021    1.059e-05    1.03366e-05     1000    
-minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.914e-06    2.63398e-06   2.0589e-05     2.375e-06    1.05498e-06     1000    
-minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.623e-06    2.15972e-06   2.0449e-05     1.943e-06    1.13537e-06     1000    
-cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.593e-06    2.09237e-06   1.8055e-05     1.843e-06    1.12211e-06     1000    
-cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.463e-06    1.98669e-06   2.1552e-05     1.733e-06    1.27574e-06     1000    
-caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.583e-06    2.04638e-06   1.9958e-05     1.803e-06    1.20769e-06     1000    
-caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       9.0733e-05    0.000464751   0.00210494    0.000381158   0.000287386     1000    
-caloFast_RMC:CaloClusterFast:CaloClusterFast                                         1.1351e-05    6.20738e-05   0.000294873   5.1974e-05    3.90304e-05     1000    
-caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.673e-06    8.75506e-06   8.4862e-05    7.8395e-06    4.20389e-06     1000    
-caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.505e-06    3.38418e-06   1.9327e-05    3.1555e-06    1.23426e-06     1000    
-caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.418e-06    5.72033e-06    3.11e-05      5.13e-06     2.13265e-06     1000    
-caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.663e-06    2.16663e-06   2.2944e-05     1.934e-06    1.03365e-06     1000    
-caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.07e-06     7.98893e-06   0.000208719    7.034e-06    7.13665e-06     1000    
-caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.683e-06    2.30817e-06   2.5489e-05     1.954e-06    1.55212e-06     1000    
-caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.039e-06    8.15326e-06   0.000191296    5.987e-06    7.45006e-06     1000    
-aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.773e-06    2.46371e-06   3.8234e-05     2.154e-06    1.71906e-06     1000    
-aprHelix:TTmakeSH:StrawHitReco                                                       6.5876e-05    0.00129934     0.895092     0.000346918    0.0282794      1000    
-aprHelix:TTmakePH:CombineStrawHits                                                   1.1292e-05    6.38135e-05   0.00131839    4.9515e-05    6.1595e-05      1000    
-aprHelix:TTDeltaFinder:DeltaFinder                                                    8.374e-05    0.00039699     0.0030477    0.000293351   0.000327888     1000    
-aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.3485e-05    6.60543e-05   0.00043955    4.9685e-05    5.22983e-05     1000    
-aprHelix:aprHelixTCFilter:TimeClusterFilter                                          1.0079e-05    1.33135e-05   4.5898e-05    1.22335e-05   3.69226e-06     1000    
-aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.1522e-05    0.000407635    0.0064413    0.000132363   0.000692865      801    
-aprHelix:TTAprHelixMerger:MergeHelices                                               1.1452e-05    1.44245e-05   4.8192e-05    1.3215e-05    3.70607e-06      801    
-aprHelix:aprHelixHSFilter:HelixFilter                                                 6.052e-06    7.89026e-06   3.4326e-05     7.074e-06     2.741e-06       801    
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkPS:PrescaleEvent                    2.464e-06    3.4228e-06    1.8286e-05     3.126e-06    1.37938e-06     1000    
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkTCFilter:TimeClusterFilter          7.695e-06    1.02042e-05   4.5928e-05    9.3675e-06    3.11454e-06     1000    
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkHSFilter:HelixFilter                5.51e-06     6.77206e-06   7.7779e-05     6.101e-06    3.29799e-06      801    
-apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.793e-06    8.45163e-06   3.5788e-05    7.7755e-06    2.51122e-06     1000    
-apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 5.009e-06    6.11883e-06   2.8454e-05     5.52e-06     2.03981e-06      801    
-apr_highP:aprHighPPS:PrescaleEvent                                                    1.693e-06    2.35619e-06   1.6561e-05     2.104e-06    1.0177e-06      1000    
-apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.161e-06    7.82703e-06   4.4554e-05     6.974e-06    2.85965e-06     1000    
-apr_highP:aprHighPHSFilter:HelixFilter                                                4.648e-06    5.91161e-06   2.3706e-05     5.27e-06     2.20498e-06      801    
-apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.663e-06    2.22821e-06   2.1842e-05     1.954e-06    1.26347e-06     1000    
-apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.242e-06    8.09636e-06   0.000176417    6.983e-06    7.80076e-06     1000    
-apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.689e-06    5.78776e-06   2.5078e-05     5.16e-06     2.09245e-06      801    
-cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.724e-06    2.26169e-06   2.2844e-05     2.024e-06    1.04158e-06     1000    
-cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.235e-06    1.24517e-05   0.000174704    9.584e-06    8.57456e-06     1000    
-cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       6.965e-06    8.50049e-06   3.2352e-05     7.795e-06    2.42035e-06     1000    
-cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.733e-06    2.39985e-06   1.6902e-05     2.074e-06    1.34595e-06     1000    
-cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.402e-06    9.35982e-06   7.3261e-05    7.0535e-06    6.19305e-06     1000    
-cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.492e-06    8.04912e-06   4.5778e-05    7.0845e-06    3.24728e-06     1000    
-cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.723e-06    2.31009e-06   1.8064e-05     2.014e-06    1.08723e-06     1000    
-cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.292e-06    8.21988e-06    0.0001881     6.983e-06    7.39659e-06     1000    
-cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.643e-06    2.18298e-06   1.7062e-05     1.934e-06    1.0048e-06      1000    
-cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.402e-06    7.88623e-06    3.667e-05     7.053e-06    2.78627e-06     1000    
-cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.673e-06    2.1107e-06    1.8155e-05     1.903e-06    9.71179e-07     1000    
-cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.012e-06    7.37911e-06    3.104e-05    6.6025e-06    2.60983e-06     1000    
-tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.723e-06    2.26823e-06   2.0248e-05    1.9935e-06    1.15464e-06     1000    
-tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                    3.099e-05    0.00147458     0.0154486    0.000856563   0.00176584      1000    
-tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.995e-06    1.2513e-05    6.7329e-05    1.16675e-05   4.10474e-06     1000    
-tprHelixUe:TThelixFinderUe:RobustHelixFinder                                         1.0671e-05    0.000296273   0.00752643    0.000134697   0.000498935      991    
-tprHelixUe:TTHelixMergerUe:MergeHelices                                               9.889e-06    1.64416e-05   0.000186958   1.4116e-05    8.57044e-06      991    
-tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.641e-06    8.56641e-06   3.5577e-05     7.394e-06    2.97867e-06      991    
-tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.944e-06    3.13306e-06   2.2262e-05     2.936e-06    1.27356e-06     1000    
-tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.7743e-05    0.00139829     0.0162024    0.000801252    0.0017563      1000    
-tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.053e-06    1.28527e-05   5.6017e-05    1.1882e-05    4.53564e-06     1000    
-tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.556e-06    0.000312701   0.00521219    0.000137518   0.000474908      992    
-tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.198e-06    1.55476e-05   6.1988e-05    1.3376e-05    6.2438e-06       992    
-tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.26e-06     8.58872e-06    3.676e-05     7.409e-06    3.41728e-06      992    
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.834e-06    3.15698e-06    1.509e-05    2.9855e-06    1.09642e-06     1000    
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.372e-06    1.00849e-05   2.7512e-05     9.538e-06    2.80802e-06     1000    
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.638e-06    6.5764e-06    4.6359e-05     5.656e-06    2.61801e-06      992    
-tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.674e-06    2.33836e-06   6.3842e-05    2.0945e-06    2.09454e-06     1000    
-tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.383e-06    8.61075e-06   0.000174665    7.686e-06    6.02922e-06     1000    
-tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.538e-06    6.13794e-06   2.8605e-05    5.2795e-06    2.34682e-06      992    
-tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.714e-06    2.25283e-06   2.1752e-05    1.9885e-06    1.14214e-06     1000    
-tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.302e-06    8.47904e-06   0.000142522    7.514e-06    5.95321e-06     1000    
-tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.729e-06    6.57655e-06   3.3324e-05     5.701e-06    2.64505e-06      998    
-tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.783e-06    2.46066e-06   1.7874e-05     2.094e-06    1.18162e-06     1000    
-tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.162e-06    8.28618e-06   3.9255e-05    7.1035e-06    3.21827e-06     1000    
-tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.588e-06    6.52356e-06   2.4035e-05    5.3655e-06    2.65645e-06      992    
-tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.643e-06    2.20799e-06   2.0089e-05     1.924e-06    1.33814e-06     1000    
-tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.372e-06    8.27972e-06   4.2581e-05    7.2835e-06    3.16318e-06     1000    
-tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.708e-06    6.43358e-06    2.607e-05     5.52e-06     2.35932e-06      992    
-mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.593e-06    2.05615e-06   1.6733e-05     1.833e-06    9.52501e-07     1000    
-mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.562e-06     8.784e-06    0.000219359   7.4895e-06    1.1129e-05      1000    
-mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.9137e-05    0.00351343     0.153802     0.00109403    0.00890585       992    
-mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2995e-05    0.000165305   0.00314605    4.5993e-05    0.000329363      992    
-mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.321e-06    2.22506e-05   0.000174724   1.7594e-05     1.67e-05        992    
-mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000243445    0.0102761     0.0537748    0.00753361    0.00884734       609    
-mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.776e-06    1.88415e-05    7.834e-05    1.6361e-05    8.7142e-06       609    
-[art]:TriggerResults:TriggerResultInserter                                            3.647e-06    4.88636e-06   2.2904e-05     4.128e-06    2.18047e-06     1000    
-cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         6.0316e-05    0.000224069   0.00115532    0.000168372   0.000193785      78     
-cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.0941e-05    1.44958e-05   2.6932e-05    1.3195e-05    3.38694e-06      78     
-cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.921e-06    8.04856e-06   1.5099e-05    7.2935e-06    2.04284e-06      78     
-cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.9925e-05    0.000209068   0.000722502   0.000159035   0.000157976      87     
-cprHelixDe:TTCalHelixMergerDe:MergeHelices                                           1.0129e-05    1.42497e-05   3.6579e-05    1.2834e-05    4.75149e-06      87     
-cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.471e-06    7.88856e-06    1.612e-05     7.094e-06    2.12144e-06      87     
-cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.24e-06     7.58554e-06   3.0939e-05     6.422e-06    3.52226e-06      87     
-cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.119e-06    7.00451e-06   2.1812e-05     6.303e-06    2.42716e-06      87     
-cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.28e-06     6.93884e-06   1.3425e-05     6.313e-06    1.47818e-06      87     
-tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.2904e-05    2.05254e-05   0.000130359   1.6236e-05    1.42488e-05      74     
-tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000285445   0.00168923    0.00562702    0.00140481    0.00101556       96     
-tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.606e-06    1.30412e-05    2.586e-05    1.24235e-05   3.31302e-06      96     
-tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.5611e-05    1.74982e-05   1.9728e-05    1.7364e-05    1.09139e-06      11     
-tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.4627e-05    2.27357e-05   5.2089e-05    2.21425e-05   6.66089e-06      90     
-tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.609e-06    7.85923e-06   2.2544e-05     7.124e-06    3.20215e-06      57     
-tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.949e-06    6.84169e-06   1.1742e-05     6.682e-06    1.54154e-06      35     
-aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.4739e-05    2.14503e-05   2.8685e-05    2.3014e-05    4.61977e-06      12     
-apr_highP:TTAprKSF:LoopHelixFit                                                      0.000214139   0.00067591    0.00137286    0.000565791   0.000432569       6     
-apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.25e-06     9.83533e-06    1.605e-05    1.1171e-05    3.53427e-06       9     
-tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        9.678e-06    1.46554e-05   2.3796e-05    1.4298e-05    3.36307e-06      29     
-tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.769e-06    5.01627e-05   0.000195434   1.36265e-05   6.7058e-05        6     
-tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                      1.105e-05    1.25452e-05   1.4167e-05    1.2503e-05    9.18684e-07       6     
-mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7393e-05    2.77299e-05   4.8453e-05    2.3665e-05    1.0131e-05       17     
-cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.6241e-05    3.48093e-05   8.1426e-05    2.0785e-05    2.69784e-05       4     
-cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000195634   0.000195634   0.000195634   0.000195634        0            1     
-cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                         1.1032e-05    1.1032e-05    1.1032e-05    1.1032e-05         0            1     
-tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000343677    0.0013041     0.0026438    0.00101068    0.000769378       5     
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1882e-05    2.34079e-05    7.306e-05     1.539e-05    2.05998e-05       7     
-apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000163062   0.000434364   0.00094693    0.000275106   0.000304708       6     
-apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               8.145e-06    1.03915e-05    1.555e-05    9.6885e-06    2.48443e-06       6     
-cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000201344   0.000990734   0.00239339    0.000377472   0.000994427       3     
-cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           9.078e-06    1.10347e-05   1.4488e-05     9.538e-06    2.44909e-06       3     
-apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.52e-06      5.52e-06      5.52e-06      5.52e-06          0            1     
+source:RootInput(read)                                                               6.4614e-05    0.000465524    0.0727762    0.000100157   0.00361706      20000   
+caloHitRec_N0Source:artFragFromDTCEvents:ArtFragmentsFromDTCEvents                   1.0821e-05    1.47094e-05   0.000365108   1.3075e-05    5.61987e-06     20000   
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.837e-06    8.32854e-05    0.0806805    1.10415e-05   0.00176621      20000   
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.834e-06    2.75917e-06   0.000238877    2.424e-06    2.68549e-06     20000   
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.603e-06    2.13213e-06   0.000163803    1.924e-06    1.70844e-06     20000   
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.533e-06    2.06252e-06   4.1268e-05     1.864e-06    1.18472e-06     20000   
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.463e-06    1.93624e-06   0.000207105    1.723e-06    1.80935e-06     20000   
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.513e-06    1.9993e-06    0.000207457    1.804e-06    1.81157e-06     20000   
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.4953e-05    0.000581722    0.0837654    0.000440087   0.00161912      20000   
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.648e-06    6.36204e-05   0.00312655    5.3192e-05    4.52942e-05     20000   
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.392e-06    8.95643e-06   0.000331363    8.096e-06    4.26086e-06     20000   
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.585e-06    3.74397e-06   4.5757e-05     3.457e-06    1.62995e-06     20000   
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.449e-06    6.05157e-06   0.000221975    5.401e-06    3.38861e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.703e-06    2.30241e-06   3.5568e-05     2.063e-06    1.24387e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.059e-06    8.08339e-06   0.000336753    7.344e-06    4.18344e-06     20000   
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.763e-06    2.28533e-06   0.00019312     2.024e-06    1.84321e-06     20000   
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.14e-06     8.19277e-06   0.000655372    6.121e-06    6.81151e-06     20000   
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.703e-06    2.55069e-06   0.000204221    2.255e-06    2.03985e-06     20000   
+aprHelix:TTmakeSH:StrawHitReco                                                       3.4908e-05    0.000456511    0.772278     0.000360189   0.00546339      20000   
+aprHelix:TTmakePH:CombineStrawHits                                                    8.496e-06    6.25965e-05   0.00110303    4.9539e-05    4.65781e-05     20000   
+aprHelix:TTDeltaFinder:DeltaFinder                                                   7.8861e-05    0.000382301   0.00415783    0.000286377   0.000311468     20000   
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2574e-05    6.58962e-05   0.000599947   4.9485e-05    5.22071e-05     20000   
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                           9.618e-06    1.36424e-05   0.000215472   1.2444e-05    4.86441e-06     20000   
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.0329e-05    0.00041849     0.0207945    0.000140162   0.000759787     16012   
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1513e-05    1.51025e-05   0.000136461   1.36565e-05   4.39736e-06     16012   
+aprHelix:aprHelixHSFilter:HelixFilter                                                 5.961e-06    7.93251e-06   0.000217365    7.153e-06    3.1807e-06      16012   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkPS:PrescaleEvent                    2.374e-06    3.56571e-06   4.3884e-05     3.266e-06    1.58527e-06     20000   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkTCFilter:TimeClusterFilter          7.234e-06    1.05247e-05   0.000107285    9.659e-06    3.35963e-06     20000   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkHSFilter:HelixFilter                5.37e-06     6.92501e-06   6.6005e-05     6.291e-06    2.37729e-06     16012   
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.502e-06    8.61351e-06   0.000212847    7.784e-06    3.66183e-06     20000   
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.83e-06     6.17415e-06   0.000461492    5.51e-06     4.30829e-06     16012   
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.754e-06    2.54286e-06   0.000210102    2.244e-06    2.06681e-06     20000   
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.242e-06    8.21012e-06   0.000212096    7.364e-06    3.20473e-06     20000   
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.859e-06    6.20494e-06   0.000106533     5.6e-06     2.25069e-06     16012   
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.694e-06    2.36454e-06   0.000186347    2.114e-06    1.86443e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.212e-06    8.15973e-06   0.000108778    7.334e-06    3.01742e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.608e-06    6.06268e-06   0.000215783    5.391e-06    3.04429e-06     16012   
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.794e-06    2.43496e-06   9.7947e-05     2.174e-06    1.4618e-06      20000   
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.056e-06    1.23588e-05   0.000182388    9.648e-06    7.23618e-06     20000   
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       6.882e-06    8.83934e-06   6.7419e-05     7.975e-06    2.93123e-06     20000   
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.723e-06    2.42937e-06   9.6314e-05     2.124e-06    1.38835e-06     20000   
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.272e-06    9.60796e-06   0.000224689    7.164e-06    6.66826e-06     20000   
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.502e-06    8.27809e-06   0.00018321     7.344e-06    3.16784e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.774e-06    2.46509e-06   3.6019e-05     2.155e-06    1.32258e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.502e-06    8.23134e-06   0.000173933    7.303e-06    3.25007e-06     20000   
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.693e-06    2.30678e-06   0.000203519    1.994e-06    1.92867e-06     20000   
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      5.993e-06    7.75741e-06   0.000185845    6.832e-06    3.14388e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.623e-06    2.11814e-06   0.000189773    1.884e-06    1.73145e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.482e-06    8.05596e-06   0.000178361    7.244e-06    3.03681e-06     20000   
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.784e-06    2.44649e-06   0.000216544    2.144e-06    1.97482e-06     20000   
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9025e-05    0.00148624     0.0231735    0.000886004   0.00186632      20000   
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.805e-06    1.34455e-05   0.000227885   1.2333e-05    5.20628e-06     20000   
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          9.989e-06    0.000306226    0.0212092    0.000127989   0.00055975      19786   
+tprHelixUe:TTHelixMergerUe:MergeHelices                                              1.0039e-05    1.70087e-05   0.000240811   1.4659e-05    7.58921e-06     19786   
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.741e-06    9.08468e-06   0.000198079   7.6755e-06    3.75597e-06     19786   
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.873e-06    3.25423e-06   0.000101224    3.035e-06    1.50392e-06     20000   
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.6271e-05    0.00140881     0.0227707    0.000824857    0.0018136      20000   
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       6.973e-06    1.32063e-05   0.000220902   1.2254e-05    4.54221e-06     20000   
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            7.654e-06    0.000327073    0.0150298    0.000135309   0.000584757     19813   
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               8.797e-06    1.61701e-05   0.000313389   1.3906e-05    8.11107e-06     19813   
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.15e-06     8.51714e-06   0.000201856    7.204e-06    3.5931e-06      19813   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.854e-06    3.2352e-06    2.9576e-05     3.035e-06    1.3614e-06      20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.221e-06    1.03557e-05   0.000334249    9.618e-06    4.02449e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.919e-06    6.89195e-06   3.9666e-05     5.992e-06    2.52632e-06     19813   
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.764e-06    2.50084e-06   0.000217255    2.245e-06    2.15529e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.392e-06    9.02009e-06   0.000269766    8.185e-06    4.42546e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.699e-06    6.35281e-06   9.0002e-05     5.53e-06     2.40806e-06     19813   
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.723e-06    2.33621e-06   7.3812e-05     2.064e-06    1.25894e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.452e-06    8.77003e-06   0.000289283    7.844e-06    5.26156e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.959e-06    6.9346e-06    0.000127634    5.951e-06    2.80343e-06     19904   
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.723e-06    2.49394e-06   0.000150216   2.1235e-06    1.72183e-06     20000   
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.301e-06    8.78431e-06   0.000208169    7.614e-06    3.51526e-06     20000   
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.728e-06    6.91355e-06   0.000183261    5.741e-06    3.60469e-06     19813   
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.653e-06    2.29369e-06   0.000203388    2.024e-06    1.84046e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.242e-06    8.45087e-06   0.000264566    7.494e-06    4.90132e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.579e-06    6.52748e-06   0.000115851    5.531e-06    2.79406e-06     19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.693e-06    2.24403e-06   0.000207938    1.993e-06    1.81573e-06     20000   
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.352e-06    9.07092e-06   0.000342063    7.514e-06    1.15359e-05     20000   
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.7494e-05    0.00335232     0.180262     0.00111952    0.00761252      19813   
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2394e-05    0.000170492   0.00695159    4.6359e-05    0.000371123     19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.39e-06     2.17555e-05   0.000325933   1.7293e-05    1.61067e-05     19813   
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000129208    0.0101031     0.0867717    0.00713221    0.00941873      12188   
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         7.383e-06    1.87205e-05   0.00506041     1.591e-05    4.77757e-05     12188   
+[art]:TriggerResults:TriggerResultInserter                                            3.526e-06    4.82859e-06   0.00031454     4.218e-06    2.93903e-06     20000   
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         4.9435e-05    0.000216178   0.00281092     0.0001514    0.000194838     1455    
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.0611e-05    1.43501e-05   0.000217517   1.3085e-05    6.54843e-06     1455    
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             6.051e-06    8.18197e-06   3.0139e-05     7.384e-06    2.4822e-06      1455    
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                          4.164e-05    0.000218068   0.00238584    0.000151199   0.000207062     1579    
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.022e-05     1.419e-05    7.4613e-05    1.3054e-05    3.90853e-06     1579    
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.821e-06    8.34909e-06    9.895e-05     7.324e-06    3.51727e-06     1579    
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.17e-06     7.21396e-06    2.625e-05     6.472e-06    2.34457e-06     1579    
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            4.949e-06    7.27306e-06   4.9695e-05     6.433e-06    2.99696e-06     1579    
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.04e-06     7.15673e-06   2.7512e-05     6.603e-06    2.40806e-06     1579    
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.2925e-05    1.99161e-05   0.000414614   1.6892e-05    1.25192e-05     1413    
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000153794   0.00174786     0.0116072    0.00148344    0.00118603      1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           7.615e-06    1.30045e-05   7.6616e-05    1.2333e-05    4.02096e-06     1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo               1.535e-05    1.86714e-05    5.258e-05    1.7274e-05    4.75442e-06      166    
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.4667e-05    2.38166e-05   9.1735e-05    2.2899e-05    7.19459e-06     1884    
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.619e-06    7.63431e-06   7.8821e-05     7.123e-06    3.71815e-06     1089    
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.449e-06    6.85046e-06   2.1972e-05     6.503e-06    2.12306e-06      695    
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.4908e-05    2.26983e-05   6.5986e-05    2.1871e-05    6.52662e-06      304    
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.00017729    0.000780451   0.00306359    0.000588304   0.000595108      92     
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              4.829e-06    8.99638e-06   0.000149295    7.424e-06    9.89785e-06      234    
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        9.939e-06    1.52672e-05   0.000221282   1.3917e-05    9.95256e-06      543    
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.478e-06    3.60698e-05   0.000301276    1.522e-05    5.3611e-05       91     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.0711e-05    1.33931e-05   2.4447e-05    1.2865e-05    2.24742e-06      91     
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7342e-05    3.11743e-05   8.5183e-05    2.7342e-05    1.28716e-05      268    
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4358e-05    2.28075e-05   4.6208e-05    2.22925e-05   6.53361e-06      72     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000168803   0.000583472   0.00134779    0.000347354   0.000459146       6     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.56e-06     7.93855e-06   1.6892e-05     7.429e-06    2.51687e-06      38     
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000175616   0.00142799     0.0051461     0.0010678    0.00102095       121    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1682e-05    1.64446e-05   3.7412e-05    1.4998e-05    4.81972e-06      139    
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000154334   0.000819513   0.00302655    0.000664189   0.000603822      208    
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.24e-06     1.12846e-05   2.4316e-05     1.08e-05     2.6802e-06       211    
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000154023   0.000991149   0.00418195    0.00110071    0.000721376      68     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.406e-06    1.16904e-05   1.9117e-05    1.1362e-05    2.27894e-06      68     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             4.92e-06     6.45546e-06   3.9176e-05     5.56e-06     4.12903e-06      69     
+cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.5801e-05    1.81491e-05   2.2973e-05    1.76435e-05   1.94803e-06      20     
+apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.6221e-05    1.76025e-05   2.7663e-05    1.71835e-05   2.17831e-06      24     
+apr_lowP_stopTarg_multiTrk:TTAprKSF:LoopHelixFit                                     0.000909689   0.00113147    0.00166636    0.00097492    0.000310969       4     
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkKSFilter:KalSeedFilter              9.097e-06    1.12565e-05   1.3246e-05    1.13415e-05   1.82615e-06       4     
+apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.2774e-05    1.35386e-05   1.4196e-05    1.3506e-05    4.76367e-07       7     
+apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                1.2044e-05    1.31592e-05   1.6372e-05    1.2373e-05    1.62631e-06       5     
+cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.18e-06     6.46637e-06    8.907e-06     6.502e-06    1.12802e-06      19     
+tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.7503e-05    2.29985e-05   3.8874e-05    1.78085e-05   9.16866e-06       4     
+cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.5278e-05    1.5278e-05    1.5278e-05    1.5278e-05         0            1     
+cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.3546e-05    1.3546e-05    1.3546e-05    1.3546e-05         0            1     
 =======================================================================================================================================================================
 DbEngine::endJob
-    Total time in reading DB: 0.816342 s
-    Total time waiting for locks: 1e-06 s
-    Total time in locks: 0.562874 s
+    Total time in reading DB: 0.556372 s
+    Total time waiting for locks: 2e-06 s
+    Total time in locks: 0.440666 s
     valcache memory: 58065 b
   Database cache stats:
     cache nTable : 11
@@ -196,257 +218,257 @@ DbEngine::endJob
     cache nPurged : 0
 
 TrigReport ---------- Event summary -------------
-TrigReport Events total = 1000 passed = 216 failed = 784
+TrigReport Events total = 20000 passed = 4452 failed = 15548
 
 TrigReport ---------- Trigger-path summary ------------
 TrigReport    Path ID        Run     Passed     Failed      Error Name
-TrigReport        100       1000          0       1000          0 tprDe_highP_stopTarg
-TrigReport        101       1000          0       1000          0 tprDe_highP
-TrigReport        110       1000         11        989          0 tprDe_lowP_stopTarg
-TrigReport        120       1000         29        971          0 tprHelixDe_ipa
-TrigReport        121       1000          7        993          0 tprHelixDe_ipa_phiScaled
-TrigReport        130       1000         74        926          0 tprHelixDe
-TrigReport        131       1000         90        910          0 tprHelixUe
-TrigReport        150       1000          0       1000          0 cprDe_highP_stopTarg
-TrigReport        151       1000          0       1000          0 cprDe_highP
-TrigReport        160       1000          0       1000          0 cprDe_lowP_stopTarg
-TrigReport        170       1000          4        996          0 cprHelixDe
-TrigReport        171       1000          2        998          0 cprHelixUe
-TrigReport        180       1000          0       1000          0 apr_highP_stopTarg
-TrigReport        181       1000          0       1000          0 apr_highP
-TrigReport        190       1000          0       1000          0 apr_lowP_stopTarg
-TrigReport        191       1000          0       1000          0 apr_lowP_stopTarg_multiTrk
-TrigReport        195       1000         12        988          0 aprHelix
-TrigReport        200       1000         25        975          0 caloFast_photon
-TrigReport        201       1000         83        917          0 caloFast_MVANNCE
-TrigReport        202       1000          0       1000          0 caloFast_cosmic
-TrigReport        210       1000         17        983          0 mprDe_highP_stopTarg
-TrigReport        220       1000          0       1000          0 caloFast_RMC
-TrigReport        310       1000          0       1000          0 cstTimeCluster
-TrigReport        320       1000          0       1000          0 cstCosmicTrackSeed
-TrigReport        400       1000          0       1000          0 minBias_SDCount
-TrigReport        410       1000          0       1000          0 minBias_CDCount
-TrigReport        500       1000          0       1000          0 caloHitRec_N0Source
+TrigReport        100      20000          0      20000          0 tprDe_highP_stopTarg
+TrigReport        101      20000          4      19996          0 tprDe_highP
+TrigReport        110      20000        166      19834          0 tprDe_lowP_stopTarg
+TrigReport        120      20000        543      19457          0 tprHelixDe_ipa
+TrigReport        121      20000        139      19861          0 tprHelixDe_ipa_phiScaled
+TrigReport        130      20000       1413      18587          0 tprHelixDe
+TrigReport        131      20000       1884      18116          0 tprHelixUe
+TrigReport        150      20000          1      19999          0 cprDe_highP_stopTarg
+TrigReport        151      20000          1      19999          0 cprDe_highP
+TrigReport        160      20000         20      19980          0 cprDe_lowP_stopTarg
+TrigReport        170      20000         72      19928          0 cprHelixDe
+TrigReport        171      20000         28      19972          0 cprHelixUe
+TrigReport        180      20000          5      19995          0 apr_highP_stopTarg
+TrigReport        181      20000          7      19993          0 apr_highP
+TrigReport        190      20000         24      19976          0 apr_lowP_stopTarg
+TrigReport        191      20000          0      20000          0 apr_lowP_stopTarg_multiTrk
+TrigReport        195      20000        304      19696          0 aprHelix
+TrigReport        200      20000        471      19529          0 caloFast_photon
+TrigReport        201      20000       1844      18156          0 caloFast_MVANNCE
+TrigReport        202      20000          0      20000          0 caloFast_cosmic
+TrigReport        210      20000        268      19732          0 mprDe_highP_stopTarg
+TrigReport        220      20000          0      20000          0 caloFast_RMC
+TrigReport        310      20000          0      20000          0 cstTimeCluster
+TrigReport        320      20000          0      20000          0 cstCosmicTrackSeed
+TrigReport        400      20000          0      20000          0 minBias_SDCount
+TrigReport        410      20000          0      20000          0 minBias_CDCount
+TrigReport        500      20000          0      20000          0 caloHitRec_N0Source
 
 TrigReport ---------- End-path summary ---------
 TrigReport        Run    Success      Error
 
 TrigReport ---------- Modules in path: aprHelix ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        195       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        195       1000       1000          0          0 aprLowPStopTargPS
-TrigReport        195       1000       1000          0          0 CaloHitMakerFast
-TrigReport        195       1000       1000          0          0 CaloClusterFast
-TrigReport        195       1000       1000          0          0 TTmakeSH
-TrigReport        195       1000       1000          0          0 TTmakePH
-TrigReport        195       1000       1000          0          0 TTDeltaFinder
-TrigReport        195       1000       1000          0          0 TTTZClusterFinder
-TrigReport        195       1000        801        199          0 aprHelixTCFilter
-TrigReport        195        801        801          0          0 TTAprHelixFinder
-TrigReport        195        801        801          0          0 TTAprHelixMerger
-TrigReport        195        801         12        789          0 aprHelixHSFilter
-TrigReport        195         12         12          0          0 aprHelixTriggerInfoMerger
+TrigReport        195      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        195      20000      20000          0          0 aprLowPStopTargPS
+TrigReport        195      20000      20000          0          0 CaloHitMakerFast
+TrigReport        195      20000      20000          0          0 CaloClusterFast
+TrigReport        195      20000      20000          0          0 TTmakeSH
+TrigReport        195      20000      20000          0          0 TTmakePH
+TrigReport        195      20000      20000          0          0 TTDeltaFinder
+TrigReport        195      20000      20000          0          0 TTTZClusterFinder
+TrigReport        195      20000      16012       3988          0 aprHelixTCFilter
+TrigReport        195      16012      16012          0          0 TTAprHelixFinder
+TrigReport        195      16012      16012          0          0 TTAprHelixMerger
+TrigReport        195      16012        304      15708          0 aprHelixHSFilter
+TrigReport        195        304        304          0          0 aprHelixTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        181       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        181       1000       1000          0          0 aprHighPPS
-TrigReport        181       1000       1000          0          0 CaloHitMakerFast
-TrigReport        181       1000       1000          0          0 CaloClusterFast
-TrigReport        181       1000       1000          0          0 TTmakeSH
-TrigReport        181       1000       1000          0          0 TTmakePH
-TrigReport        181       1000       1000          0          0 TTDeltaFinder
-TrigReport        181       1000       1000          0          0 TTTZClusterFinder
-TrigReport        181       1000        801        199          0 aprHighPTCFilter
-TrigReport        181        801        801          0          0 TTAprHelixFinder
-TrigReport        181        801        801          0          0 TTAprHelixMerger
-TrigReport        181        801          9        792          0 aprHighPHSFilter
-TrigReport        181          9          9          0          0 TTAprKSF
-TrigReport        181          9          0          9          0 aprHighPKSFilter
-TrigReport        181          0          0          0          0 aprHighPTriggerInfoMerger
+TrigReport        181      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        181      20000      20000          0          0 aprHighPPS
+TrigReport        181      20000      20000          0          0 CaloHitMakerFast
+TrigReport        181      20000      20000          0          0 CaloClusterFast
+TrigReport        181      20000      20000          0          0 TTmakeSH
+TrigReport        181      20000      20000          0          0 TTmakePH
+TrigReport        181      20000      20000          0          0 TTDeltaFinder
+TrigReport        181      20000      20000          0          0 TTTZClusterFinder
+TrigReport        181      20000      16012       3988          0 aprHighPTCFilter
+TrigReport        181      16012      16012          0          0 TTAprHelixFinder
+TrigReport        181      16012      16012          0          0 TTAprHelixMerger
+TrigReport        181      16012        234      15778          0 aprHighPHSFilter
+TrigReport        181        234        234          0          0 TTAprKSF
+TrigReport        181        234          7        227          0 aprHighPKSFilter
+TrigReport        181          7          7          0          0 aprHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        180       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        180       1000       1000          0          0 aprHighPStopTargPS
-TrigReport        180       1000       1000          0          0 CaloHitMakerFast
-TrigReport        180       1000       1000          0          0 CaloClusterFast
-TrigReport        180       1000       1000          0          0 TTmakeSH
-TrigReport        180       1000       1000          0          0 TTmakePH
-TrigReport        180       1000       1000          0          0 TTDeltaFinder
-TrigReport        180       1000       1000          0          0 TTTZClusterFinder
-TrigReport        180       1000        801        199          0 aprHighPStopTargTCFilter
-TrigReport        180        801        801          0          0 TTAprHelixFinder
-TrigReport        180        801        801          0          0 TTAprHelixMerger
-TrigReport        180        801          1        800          0 aprHighPStopTargHSFilter
-TrigReport        180          1          1          0          0 TTAprKSF
-TrigReport        180          1          0          1          0 aprHighPStopTargKSFilter
-TrigReport        180          0          0          0          0 aprHighPStopTargTriggerInfoMerger
+TrigReport        180      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        180      20000      20000          0          0 aprHighPStopTargPS
+TrigReport        180      20000      20000          0          0 CaloHitMakerFast
+TrigReport        180      20000      20000          0          0 CaloClusterFast
+TrigReport        180      20000      20000          0          0 TTmakeSH
+TrigReport        180      20000      20000          0          0 TTmakePH
+TrigReport        180      20000      20000          0          0 TTDeltaFinder
+TrigReport        180      20000      20000          0          0 TTTZClusterFinder
+TrigReport        180      20000      16012       3988          0 aprHighPStopTargTCFilter
+TrigReport        180      16012      16012          0          0 TTAprHelixFinder
+TrigReport        180      16012      16012          0          0 TTAprHelixMerger
+TrigReport        180      16012         69      15943          0 aprHighPStopTargHSFilter
+TrigReport        180         69         69          0          0 TTAprKSF
+TrigReport        180         69          5         64          0 aprHighPStopTargKSFilter
+TrigReport        180          5          5          0          0 aprHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        190       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        190       1000       1000          0          0 aprLowPStopTargPS
-TrigReport        190       1000       1000          0          0 CaloHitMakerFast
-TrigReport        190       1000       1000          0          0 CaloClusterFast
-TrigReport        190       1000       1000          0          0 TTmakeSH
-TrigReport        190       1000       1000          0          0 TTmakePH
-TrigReport        190       1000       1000          0          0 TTDeltaFinder
-TrigReport        190       1000       1000          0          0 TTTZClusterFinder
-TrigReport        190       1000        801        199          0 aprLowPStopTargTCFilter
-TrigReport        190        801        801          0          0 TTAprHelixFinder
-TrigReport        190        801        801          0          0 TTAprHelixMerger
-TrigReport        190        801          6        795          0 aprLowPStopTargHSFilter
-TrigReport        190          6          6          0          0 TTAprKSF
-TrigReport        190          6          0          6          0 aprLowPStopTargKSFilter
-TrigReport        190          0          0          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport        190      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        190      20000      20000          0          0 aprLowPStopTargPS
+TrigReport        190      20000      20000          0          0 CaloHitMakerFast
+TrigReport        190      20000      20000          0          0 CaloClusterFast
+TrigReport        190      20000      20000          0          0 TTmakeSH
+TrigReport        190      20000      20000          0          0 TTmakePH
+TrigReport        190      20000      20000          0          0 TTDeltaFinder
+TrigReport        190      20000      20000          0          0 TTTZClusterFinder
+TrigReport        190      20000      16012       3988          0 aprLowPStopTargTCFilter
+TrigReport        190      16012      16012          0          0 TTAprHelixFinder
+TrigReport        190      16012      16012          0          0 TTAprHelixMerger
+TrigReport        190      16012        211      15801          0 aprLowPStopTargHSFilter
+TrigReport        190        211        211          0          0 TTAprKSF
+TrigReport        190        211         24        187          0 aprLowPStopTargKSFilter
+TrigReport        190         24         24          0          0 aprLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_stopTarg_multiTrk ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        191       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        191       1000       1000          0          0 aprLowPStopTargMultiTrkPS
-TrigReport        191       1000       1000          0          0 CaloHitMakerFast
-TrigReport        191       1000       1000          0          0 CaloClusterFast
-TrigReport        191       1000       1000          0          0 TTmakeSH
-TrigReport        191       1000       1000          0          0 TTmakePH
-TrigReport        191       1000       1000          0          0 TTDeltaFinder
-TrigReport        191       1000       1000          0          0 TTTZClusterFinder
-TrigReport        191       1000        801        199          0 aprLowPStopTargMultiTrkTCFilter
-TrigReport        191        801        801          0          0 TTAprHelixFinder
-TrigReport        191        801        801          0          0 TTAprHelixMerger
-TrigReport        191        801          0        801          0 aprLowPStopTargMultiTrkHSFilter
-TrigReport        191          0          0          0          0 TTAprKSF
-TrigReport        191          0          0          0          0 aprLowPStopTargMultiTrkKSFilter
+TrigReport        191      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        191      20000      20000          0          0 aprLowPStopTargMultiTrkPS
+TrigReport        191      20000      20000          0          0 CaloHitMakerFast
+TrigReport        191      20000      20000          0          0 CaloClusterFast
+TrigReport        191      20000      20000          0          0 TTmakeSH
+TrigReport        191      20000      20000          0          0 TTmakePH
+TrigReport        191      20000      20000          0          0 TTDeltaFinder
+TrigReport        191      20000      20000          0          0 TTTZClusterFinder
+TrigReport        191      20000      16012       3988          0 aprLowPStopTargMultiTrkTCFilter
+TrigReport        191      16012      16012          0          0 TTAprHelixFinder
+TrigReport        191      16012      16012          0          0 TTAprHelixMerger
+TrigReport        191      16012          4      16008          0 aprLowPStopTargMultiTrkHSFilter
+TrigReport        191          4          4          0          0 TTAprKSF
+TrigReport        191          4          0          4          0 aprLowPStopTargMultiTrkKSFilter
 TrigReport        191          0          0          0          0 aprLowPStopTargMultiTrkTriggerInfoMerger
 
 TrigReport ---------- Modules in path: caloFast_MVANNCE ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        201       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        201       1000       1000          0          0 caloFastMVANNCEPS
-TrigReport        201       1000       1000          0          0 CaloHitMakerFast
-TrigReport        201       1000       1000          0          0 CaloClusterFast
-TrigReport        201       1000         83        917          0 caloFastMVANNCEFilter
+TrigReport        201      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        201      20000      20000          0          0 caloFastMVANNCEPS
+TrigReport        201      20000      20000          0          0 CaloHitMakerFast
+TrigReport        201      20000      20000          0          0 CaloClusterFast
+TrigReport        201      20000       1844      18156          0 caloFastMVANNCEFilter
 
 TrigReport ---------- Modules in path: caloFast_RMC ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        220       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        220       1000       1000          0          0 caloFastRMCPS
-TrigReport        220       1000       1000          0          0 CaloHitMakerFast
-TrigReport        220       1000       1000          0          0 CaloClusterFast
-TrigReport        220       1000          0       1000          0 caloFastRMCFilter
+TrigReport        220      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        220      20000      20000          0          0 caloFastRMCPS
+TrigReport        220      20000      20000          0          0 CaloHitMakerFast
+TrigReport        220      20000      20000          0          0 CaloClusterFast
+TrigReport        220      20000          0      20000          0 caloFastRMCFilter
 
 TrigReport ---------- Modules in path: caloFast_cosmic ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        202       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        202       1000       1000          0          0 caloFastCosmicPS
-TrigReport        202       1000       1000          0          0 CaloHitMakerFast
-TrigReport        202       1000       1000          0          0 CaloClusterFast
-TrigReport        202       1000          0       1000          0 caloFastCosmicFilter
+TrigReport        202      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        202      20000      20000          0          0 caloFastCosmicPS
+TrigReport        202      20000      20000          0          0 CaloHitMakerFast
+TrigReport        202      20000      20000          0          0 CaloClusterFast
+TrigReport        202      20000          0      20000          0 caloFastCosmicFilter
 
 TrigReport ---------- Modules in path: caloFast_photon ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        200       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        200       1000       1000          0          0 caloFastPhotonPS
-TrigReport        200       1000       1000          0          0 CaloHitMakerFast
-TrigReport        200       1000       1000          0          0 CaloClusterFast
-TrigReport        200       1000         25        975          0 caloFastPhotonFilter
+TrigReport        200      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        200      20000      20000          0          0 caloFastPhotonPS
+TrigReport        200      20000      20000          0          0 CaloHitMakerFast
+TrigReport        200      20000      20000          0          0 CaloClusterFast
+TrigReport        200      20000        471      19529          0 caloFastPhotonFilter
 
 TrigReport ---------- Modules in path: caloHitRec_N0Source ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        500       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        500       1000          0       1000          0 caloHitRecN0SourcePS
+TrigReport        500      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        500      20000          0      20000          0 caloHitRecN0SourcePS
 TrigReport        500          0          0          0          0 CaloHitMakerFast
 TrigReport        500          0          0          0          0 caloHitRecN0SourceFilter
 
 TrigReport ---------- Modules in path: cprDe_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        151       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        151       1000       1000          0          0 cprDeHighPPS
-TrigReport        151       1000       1000          0          0 CaloHitMakerFast
-TrigReport        151       1000       1000          0          0 CaloClusterFast
-TrigReport        151       1000       1000          0          0 TTmakeSH
-TrigReport        151       1000       1000          0          0 TTmakePH
-TrigReport        151       1000       1000          0          0 TTDeltaFinder
-TrigReport        151       1000       1000          0          0 TTCalTimePeakFinder
-TrigReport        151       1000         87        913          0 cprDeHighPTCFilter
-TrigReport        151         87         87          0          0 TTCalHelixFinderDe
-TrigReport        151         87         87          0          0 TTCalHelixMergerDe
-TrigReport        151         87          1         86          0 cprDeHighPHSFilter
-TrigReport        151          1          1          0          0 TTCalSeedFitDe
-TrigReport        151          1          0          1          0 cprDeHighPKSFilter
-TrigReport        151          0          0          0          0 cprDeHighPTriggerInfoMerger
+TrigReport        151      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        151      20000      20000          0          0 cprDeHighPPS
+TrigReport        151      20000      20000          0          0 CaloHitMakerFast
+TrigReport        151      20000      20000          0          0 CaloClusterFast
+TrigReport        151      20000      20000          0          0 TTmakeSH
+TrigReport        151      20000      20000          0          0 TTmakePH
+TrigReport        151      20000      20000          0          0 TTDeltaFinder
+TrigReport        151      20000      20000          0          0 TTCalTimePeakFinder
+TrigReport        151      20000       1579      18421          0 cprDeHighPTCFilter
+TrigReport        151       1579       1579          0          0 TTCalHelixFinderDe
+TrigReport        151       1579       1579          0          0 TTCalHelixMergerDe
+TrigReport        151       1579         38       1541          0 cprDeHighPHSFilter
+TrigReport        151         38         38          0          0 TTCalSeedFitDe
+TrigReport        151         38          1         37          0 cprDeHighPKSFilter
+TrigReport        151          1          1          0          0 cprDeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprDe_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        150       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        150       1000       1000          0          0 cprDeHighPStopTargPS
-TrigReport        150       1000       1000          0          0 CaloHitMakerFast
-TrigReport        150       1000       1000          0          0 CaloClusterFast
-TrigReport        150       1000       1000          0          0 TTmakeSH
-TrigReport        150       1000       1000          0          0 TTmakePH
-TrigReport        150       1000       1000          0          0 TTDeltaFinder
-TrigReport        150       1000       1000          0          0 TTCalTimePeakFinder
-TrigReport        150       1000         87        913          0 cprDeHighPStopTargTCFilter
-TrigReport        150         87         87          0          0 TTCalHelixFinderDe
-TrigReport        150         87         87          0          0 TTCalHelixMergerDe
-TrigReport        150         87          0         87          0 cprDeHighPStopTargHSFilter
-TrigReport        150          0          0          0          0 TTCalSeedFitDe
-TrigReport        150          0          0          0          0 cprDeHighPStopTargKSFilter
-TrigReport        150          0          0          0          0 cprDeHighPStopTargTriggerInfoMerger
+TrigReport        150      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        150      20000      20000          0          0 cprDeHighPStopTargPS
+TrigReport        150      20000      20000          0          0 CaloHitMakerFast
+TrigReport        150      20000      20000          0          0 CaloClusterFast
+TrigReport        150      20000      20000          0          0 TTmakeSH
+TrigReport        150      20000      20000          0          0 TTmakePH
+TrigReport        150      20000      20000          0          0 TTDeltaFinder
+TrigReport        150      20000      20000          0          0 TTCalTimePeakFinder
+TrigReport        150      20000       1579      18421          0 cprDeHighPStopTargTCFilter
+TrigReport        150       1579       1579          0          0 TTCalHelixFinderDe
+TrigReport        150       1579       1579          0          0 TTCalHelixMergerDe
+TrigReport        150       1579         19       1560          0 cprDeHighPStopTargHSFilter
+TrigReport        150         19         19          0          0 TTCalSeedFitDe
+TrigReport        150         19          1         18          0 cprDeHighPStopTargKSFilter
+TrigReport        150          1          1          0          0 cprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprDe_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        160       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        160       1000       1000          0          0 cprDeLowPStopTargPS
-TrigReport        160       1000       1000          0          0 CaloHitMakerFast
-TrigReport        160       1000       1000          0          0 CaloClusterFast
-TrigReport        160       1000       1000          0          0 TTmakeSH
-TrigReport        160       1000       1000          0          0 TTmakePH
-TrigReport        160       1000       1000          0          0 TTDeltaFinder
-TrigReport        160       1000       1000          0          0 TTCalTimePeakFinder
-TrigReport        160       1000         87        913          0 cprDeLowPStopTargTCFilter
-TrigReport        160         87         87          0          0 TTCalHelixFinderDe
-TrigReport        160         87         87          0          0 TTCalHelixMergerDe
-TrigReport        160         87          3         84          0 cprDeLowPStopTargHSFilter
-TrigReport        160          3          3          0          0 TTCalSeedFitDe
-TrigReport        160          3          0          3          0 cprDeLowPStopTargKSFilter
-TrigReport        160          0          0          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport        160      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        160      20000      20000          0          0 cprDeLowPStopTargPS
+TrigReport        160      20000      20000          0          0 CaloHitMakerFast
+TrigReport        160      20000      20000          0          0 CaloClusterFast
+TrigReport        160      20000      20000          0          0 TTmakeSH
+TrigReport        160      20000      20000          0          0 TTmakePH
+TrigReport        160      20000      20000          0          0 TTDeltaFinder
+TrigReport        160      20000      20000          0          0 TTCalTimePeakFinder
+TrigReport        160      20000       1579      18421          0 cprDeLowPStopTargTCFilter
+TrigReport        160       1579       1579          0          0 TTCalHelixFinderDe
+TrigReport        160       1579       1579          0          0 TTCalHelixMergerDe
+TrigReport        160       1579         68       1511          0 cprDeLowPStopTargHSFilter
+TrigReport        160         68         68          0          0 TTCalSeedFitDe
+TrigReport        160         68         20         48          0 cprDeLowPStopTargKSFilter
+TrigReport        160         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprHelixDe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        170       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        170       1000       1000          0          0 cprHelixDePS
-TrigReport        170       1000       1000          0          0 CaloHitMakerFast
-TrigReport        170       1000       1000          0          0 CaloClusterFast
-TrigReport        170       1000       1000          0          0 TTmakeSH
-TrigReport        170       1000       1000          0          0 TTmakePH
-TrigReport        170       1000       1000          0          0 TTDeltaFinder
-TrigReport        170       1000       1000          0          0 TTCalTimePeakFinder
-TrigReport        170       1000         87        913          0 cprHelixDeTCFilter
-TrigReport        170         87         87          0          0 TTCalHelixFinderDe
-TrigReport        170         87         87          0          0 TTCalHelixMergerDe
-TrigReport        170         87          4         83          0 cprHelixDeHSFilter
-TrigReport        170          4          4          0          0 cprHelixDeTriggerInfoMerger
+TrigReport        170      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        170      20000      20000          0          0 cprHelixDePS
+TrigReport        170      20000      20000          0          0 CaloHitMakerFast
+TrigReport        170      20000      20000          0          0 CaloClusterFast
+TrigReport        170      20000      20000          0          0 TTmakeSH
+TrigReport        170      20000      20000          0          0 TTmakePH
+TrigReport        170      20000      20000          0          0 TTDeltaFinder
+TrigReport        170      20000      20000          0          0 TTCalTimePeakFinder
+TrigReport        170      20000       1579      18421          0 cprHelixDeTCFilter
+TrigReport        170       1579       1579          0          0 TTCalHelixFinderDe
+TrigReport        170       1579       1579          0          0 TTCalHelixMergerDe
+TrigReport        170       1579         72       1507          0 cprHelixDeHSFilter
+TrigReport        170         72         72          0          0 cprHelixDeTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprHelixUe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        171       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        171       1000       1000          0          0 cprHelixUePS
-TrigReport        171       1000       1000          0          0 CaloHitMakerFast
-TrigReport        171       1000       1000          0          0 CaloClusterFast
-TrigReport        171       1000       1000          0          0 TTmakeSH
-TrigReport        171       1000       1000          0          0 TTmakePH
-TrigReport        171       1000       1000          0          0 TTDeltaFinder
-TrigReport        171       1000       1000          0          0 TTCalTimePeakFinderUe
-TrigReport        171       1000         78        922          0 cprHelixUeTCFilter
-TrigReport        171         78         78          0          0 TTCalHelixFinderUe
-TrigReport        171         78         78          0          0 TTCalHelixMergerUe
-TrigReport        171         78          2         76          0 cprHelixUeHSFilter
+TrigReport        171      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        171      20000      20000          0          0 cprHelixUePS
+TrigReport        171      20000      20000          0          0 CaloHitMakerFast
+TrigReport        171      20000      20000          0          0 CaloClusterFast
+TrigReport        171      20000      20000          0          0 TTmakeSH
+TrigReport        171      20000      20000          0          0 TTmakePH
+TrigReport        171      20000      20000          0          0 TTDeltaFinder
+TrigReport        171      20000      20000          0          0 TTCalTimePeakFinderUe
+TrigReport        171      20000       1455      18545          0 cprHelixUeTCFilter
+TrigReport        171       1455       1455          0          0 TTCalHelixFinderUe
+TrigReport        171       1455       1455          0          0 TTCalHelixMergerUe
+TrigReport        171       1455         28       1427          0 cprHelixUeHSFilter
 
 TrigReport ---------- Modules in path: cstCosmicTrackSeed ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        320       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        320       1000          0       1000          0 cstCosmicTrackSeedPS
+TrigReport        320      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        320      20000          0      20000          0 cstCosmicTrackSeedPS
 TrigReport        320          0          0          0          0 TTmakeSH
 TrigReport        320          0          0          0          0 TTmakePH
 TrigReport        320          0          0          0          0 cstCosmicTrackSeedSDCountFilter
@@ -458,8 +480,8 @@ TrigReport        320          0          0          0          0 cstCosmicTrack
 
 TrigReport ---------- Modules in path: cstTimeCluster ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        310       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        310       1000          0       1000          0 cstTimeClusterPS
+TrigReport        310      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        310      20000          0      20000          0 cstTimeClusterPS
 TrigReport        310          0          0          0          0 TTmakeSH
 TrigReport        310          0          0          0          0 TTmakePH
 TrigReport        310          0          0          0          0 cstTimeClusterSDCountFilter
@@ -469,292 +491,292 @@ TrigReport        310          0          0          0          0 cstTimeCluster
 
 TrigReport ---------- Modules in path: minBias_CDCount ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        410       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        410       1000          0       1000          0 minBiasCDCountPS
+TrigReport        410      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        410      20000          0      20000          0 minBiasCDCountPS
 TrigReport        410          0          0          0          0 minBiasCDCountFilter
 
 TrigReport ---------- Modules in path: minBias_SDCount ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        400       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        400       1000          0       1000          0 minBiasSDCountPS
+TrigReport        400      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        400      20000          0      20000          0 minBiasSDCountPS
 TrigReport        400          0          0          0          0 minBiasSDCountFilter
 
 TrigReport ---------- Modules in path: mprDe_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        210       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        210       1000       1000          0          0 mprDeHighPStopTargPS
-TrigReport        210       1000       1000          0          0 CaloHitMakerFast
-TrigReport        210       1000       1000          0          0 CaloClusterFast
-TrigReport        210       1000       1000          0          0 TTmakeSH
-TrigReport        210       1000       1000          0          0 TTmakePH
-TrigReport        210       1000       1000          0          0 TTDeltaFinder
-TrigReport        210       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        210       1000        992          8          0 mprDeHighPStopTargTCFilter
-TrigReport        210        992        992          0          0 TTRobustMultiHelixFinder
-TrigReport        210        992        992          0          0 TTMprHelixMergerDe
-TrigReport        210        992        609        383          0 mprDeHighPStopTargHSFilter
-TrigReport        210        609        609          0          0 TTMprKSFDe
-TrigReport        210        609         17        592          0 mprDeHighPStopTargKSFilter
-TrigReport        210         17         17          0          0 mprDeHighPStopTargTriggerInfoMerger
+TrigReport        210      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        210      20000      20000          0          0 mprDeHighPStopTargPS
+TrigReport        210      20000      20000          0          0 CaloHitMakerFast
+TrigReport        210      20000      20000          0          0 CaloClusterFast
+TrigReport        210      20000      20000          0          0 TTmakeSH
+TrigReport        210      20000      20000          0          0 TTmakePH
+TrigReport        210      20000      20000          0          0 TTDeltaFinder
+TrigReport        210      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        210      20000      19813        187          0 mprDeHighPStopTargTCFilter
+TrigReport        210      19813      19813          0          0 TTRobustMultiHelixFinder
+TrigReport        210      19813      19813          0          0 TTMprHelixMergerDe
+TrigReport        210      19813      12188       7625          0 mprDeHighPStopTargHSFilter
+TrigReport        210      12188      12188          0          0 TTMprKSFDe
+TrigReport        210      12188        268      11920          0 mprDeHighPStopTargKSFilter
+TrigReport        210        268        268          0          0 mprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        101       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        101       1000       1000          0          0 tprDeHighPPS
-TrigReport        101       1000       1000          0          0 CaloHitMakerFast
-TrigReport        101       1000       1000          0          0 CaloClusterFast
-TrigReport        101       1000       1000          0          0 TTmakeSH
-TrigReport        101       1000       1000          0          0 TTmakePH
-TrigReport        101       1000       1000          0          0 TTDeltaFinder
-TrigReport        101       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        101       1000        992          8          0 tprDeHighPTCFilter
-TrigReport        101        992        992          0          0 TThelixFinder
-TrigReport        101        992        992          0          0 TTHelixMergerDe
-TrigReport        101        992         57        935          0 tprDeHighPHSFilter
-TrigReport        101         57         57          0          0 TTKSFDe
-TrigReport        101         57          0         57          0 tprDeHighPKSFilter
-TrigReport        101          0          0          0          0 tprDeHighPTriggerInfoMerger
+TrigReport        101      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        101      20000      20000          0          0 tprDeHighPPS
+TrigReport        101      20000      20000          0          0 CaloHitMakerFast
+TrigReport        101      20000      20000          0          0 CaloClusterFast
+TrigReport        101      20000      20000          0          0 TTmakeSH
+TrigReport        101      20000      20000          0          0 TTmakePH
+TrigReport        101      20000      20000          0          0 TTDeltaFinder
+TrigReport        101      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        101      20000      19813        187          0 tprDeHighPTCFilter
+TrigReport        101      19813      19813          0          0 TThelixFinder
+TrigReport        101      19813      19813          0          0 TTHelixMergerDe
+TrigReport        101      19813       1089      18724          0 tprDeHighPHSFilter
+TrigReport        101       1089       1089          0          0 TTKSFDe
+TrigReport        101       1089          4       1085          0 tprDeHighPKSFilter
+TrigReport        101          4          4          0          0 tprDeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        100       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        100       1000       1000          0          0 tprDeHighPStopTargPS
-TrigReport        100       1000       1000          0          0 CaloHitMakerFast
-TrigReport        100       1000       1000          0          0 CaloClusterFast
-TrigReport        100       1000       1000          0          0 TTmakeSH
-TrigReport        100       1000       1000          0          0 TTmakePH
-TrigReport        100       1000       1000          0          0 TTDeltaFinder
-TrigReport        100       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        100       1000        992          8          0 tprDeHighPStopTargTCFilter
-TrigReport        100        992        992          0          0 TThelixFinder
-TrigReport        100        992        992          0          0 TTHelixMergerDe
-TrigReport        100        992         35        957          0 tprDeHighPStopTargHSFilter
-TrigReport        100         35         35          0          0 TTKSFDe
-TrigReport        100         35          0         35          0 tprDeHighPStopTargKSFilter
+TrigReport        100      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        100      20000      20000          0          0 tprDeHighPStopTargPS
+TrigReport        100      20000      20000          0          0 CaloHitMakerFast
+TrigReport        100      20000      20000          0          0 CaloClusterFast
+TrigReport        100      20000      20000          0          0 TTmakeSH
+TrigReport        100      20000      20000          0          0 TTmakePH
+TrigReport        100      20000      20000          0          0 TTDeltaFinder
+TrigReport        100      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        100      20000      19813        187          0 tprDeHighPStopTargTCFilter
+TrigReport        100      19813      19813          0          0 TThelixFinder
+TrigReport        100      19813      19813          0          0 TTHelixMergerDe
+TrigReport        100      19813        695      19118          0 tprDeHighPStopTargHSFilter
+TrigReport        100        695        695          0          0 TTKSFDe
+TrigReport        100        695          0        695          0 tprDeHighPStopTargKSFilter
 TrigReport        100          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        110       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        110       1000       1000          0          0 tprDeLowPStopTargPS
-TrigReport        110       1000       1000          0          0 CaloHitMakerFast
-TrigReport        110       1000       1000          0          0 CaloClusterFast
-TrigReport        110       1000       1000          0          0 TTmakeSH
-TrigReport        110       1000       1000          0          0 TTmakePH
-TrigReport        110       1000       1000          0          0 TTDeltaFinder
-TrigReport        110       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        110       1000        998          2          0 tprDeLowPStopTargTCFilter
-TrigReport        110        998        998          0          0 TThelixFinder
-TrigReport        110        998        998          0          0 TTHelixMergerDe
-TrigReport        110        998         96        902          0 tprDeLowPStopTargHSFilter
-TrigReport        110         96         96          0          0 TTKSFDe
-TrigReport        110         96         11         85          0 tprDeLowPStopTargKSFilter
-TrigReport        110         11         11          0          0 tprDeLowPStopTargTriggerInfoMerger
+TrigReport        110      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        110      20000      20000          0          0 tprDeLowPStopTargPS
+TrigReport        110      20000      20000          0          0 CaloHitMakerFast
+TrigReport        110      20000      20000          0          0 CaloClusterFast
+TrigReport        110      20000      20000          0          0 TTmakeSH
+TrigReport        110      20000      20000          0          0 TTmakePH
+TrigReport        110      20000      20000          0          0 TTDeltaFinder
+TrigReport        110      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        110      20000      19904         96          0 tprDeLowPStopTargTCFilter
+TrigReport        110      19904      19904          0          0 TThelixFinder
+TrigReport        110      19904      19904          0          0 TTHelixMergerDe
+TrigReport        110      19904       1729      18175          0 tprDeLowPStopTargHSFilter
+TrigReport        110       1729       1729          0          0 TTKSFDe
+TrigReport        110       1729        166       1563          0 tprDeLowPStopTargKSFilter
+TrigReport        110        166        166          0          0 tprDeLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        130       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        130       1000       1000          0          0 tprHelixDePS
-TrigReport        130       1000       1000          0          0 CaloHitMakerFast
-TrigReport        130       1000       1000          0          0 CaloClusterFast
-TrigReport        130       1000       1000          0          0 TTmakeSH
-TrigReport        130       1000       1000          0          0 TTmakePH
-TrigReport        130       1000       1000          0          0 TTDeltaFinder
-TrigReport        130       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        130       1000        992          8          0 tprHelixDeTCFilter
-TrigReport        130        992        992          0          0 TThelixFinder
-TrigReport        130        992        992          0          0 TTHelixMergerDe
-TrigReport        130        992         74        918          0 tprHelixDeHSFilter
-TrigReport        130         74         74          0          0 tprHelixDeTriggerInfoMerger
+TrigReport        130      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        130      20000      20000          0          0 tprHelixDePS
+TrigReport        130      20000      20000          0          0 CaloHitMakerFast
+TrigReport        130      20000      20000          0          0 CaloClusterFast
+TrigReport        130      20000      20000          0          0 TTmakeSH
+TrigReport        130      20000      20000          0          0 TTmakePH
+TrigReport        130      20000      20000          0          0 TTDeltaFinder
+TrigReport        130      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        130      20000      19813        187          0 tprHelixDeTCFilter
+TrigReport        130      19813      19813          0          0 TThelixFinder
+TrigReport        130      19813      19813          0          0 TTHelixMergerDe
+TrigReport        130      19813       1413      18400          0 tprHelixDeHSFilter
+TrigReport        130       1413       1413          0          0 tprHelixDeTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe_ipa ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        120       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        120       1000       1000          0          0 tprHelixDeIpaPS
-TrigReport        120       1000       1000          0          0 CaloHitMakerFast
-TrigReport        120       1000       1000          0          0 CaloClusterFast
-TrigReport        120       1000       1000          0          0 TTmakeSH
-TrigReport        120       1000       1000          0          0 TTmakePH
-TrigReport        120       1000       1000          0          0 TTDeltaFinder
-TrigReport        120       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        120       1000        992          8          0 tprHelixDeIpaTCFilter
-TrigReport        120        992        992          0          0 TThelixFinder
-TrigReport        120        992        992          0          0 TTHelixMergerDe
-TrigReport        120        992         29        963          0 tprHelixDeIpaHSFilter
-TrigReport        120         29         29          0          0 tprHelixDeIpaTriggerInfoMerger
+TrigReport        120      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        120      20000      20000          0          0 tprHelixDeIpaPS
+TrigReport        120      20000      20000          0          0 CaloHitMakerFast
+TrigReport        120      20000      20000          0          0 CaloClusterFast
+TrigReport        120      20000      20000          0          0 TTmakeSH
+TrigReport        120      20000      20000          0          0 TTmakePH
+TrigReport        120      20000      20000          0          0 TTDeltaFinder
+TrigReport        120      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        120      20000      19813        187          0 tprHelixDeIpaTCFilter
+TrigReport        120      19813      19813          0          0 TThelixFinder
+TrigReport        120      19813      19813          0          0 TTHelixMergerDe
+TrigReport        120      19813        543      19270          0 tprHelixDeIpaHSFilter
+TrigReport        120        543        543          0          0 tprHelixDeIpaTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe_ipa_phiScaled ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        121       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        121       1000       1000          0          0 tprHelixDeIpaPhiScaledPS
-TrigReport        121       1000       1000          0          0 CaloHitMakerFast
-TrigReport        121       1000       1000          0          0 CaloClusterFast
-TrigReport        121       1000       1000          0          0 TTmakeSH
-TrigReport        121       1000       1000          0          0 TTmakePH
-TrigReport        121       1000       1000          0          0 TTDeltaFinder
-TrigReport        121       1000       1000          0          0 TTtimeClusterFinder
-TrigReport        121       1000        992          8          0 tprHelixDeIpaPhiScaledTCFilter
-TrigReport        121        992        992          0          0 TThelixFinder
-TrigReport        121        992        992          0          0 TTHelixMergerDe
-TrigReport        121        992          7        985          0 tprHelixDeIpaPhiScaledHSFilter
-TrigReport        121          7          7          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+TrigReport        121      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        121      20000      20000          0          0 tprHelixDeIpaPhiScaledPS
+TrigReport        121      20000      20000          0          0 CaloHitMakerFast
+TrigReport        121      20000      20000          0          0 CaloClusterFast
+TrigReport        121      20000      20000          0          0 TTmakeSH
+TrigReport        121      20000      20000          0          0 TTmakePH
+TrigReport        121      20000      20000          0          0 TTDeltaFinder
+TrigReport        121      20000      20000          0          0 TTtimeClusterFinder
+TrigReport        121      20000      19813        187          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport        121      19813      19813          0          0 TThelixFinder
+TrigReport        121      19813      19813          0          0 TTHelixMergerDe
+TrigReport        121      19813        139      19674          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport        121        139        139          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixUe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
-TrigReport        131       1000       1000          0          0 artFragFromDTCEvents
-TrigReport        131       1000       1000          0          0 tprHelixUePS
-TrigReport        131       1000       1000          0          0 CaloHitMakerFast
-TrigReport        131       1000       1000          0          0 CaloClusterFast
-TrigReport        131       1000       1000          0          0 TTmakeSH
-TrigReport        131       1000       1000          0          0 TTmakePH
-TrigReport        131       1000       1000          0          0 TTDeltaFinder
-TrigReport        131       1000       1000          0          0 TTtimeClusterFinderUe
-TrigReport        131       1000        991          9          0 tprHelixUeTCFilter
-TrigReport        131        991        991          0          0 TThelixFinderUe
-TrigReport        131        991        991          0          0 TTHelixMergerUe
-TrigReport        131        991         90        901          0 tprHelixUeHSFilter
-TrigReport        131         90         90          0          0 tprHelixUeTriggerInfoMerger
+TrigReport        131      20000      20000          0          0 artFragFromDTCEvents
+TrigReport        131      20000      20000          0          0 tprHelixUePS
+TrigReport        131      20000      20000          0          0 CaloHitMakerFast
+TrigReport        131      20000      20000          0          0 CaloClusterFast
+TrigReport        131      20000      20000          0          0 TTmakeSH
+TrigReport        131      20000      20000          0          0 TTmakePH
+TrigReport        131      20000      20000          0          0 TTDeltaFinder
+TrigReport        131      20000      20000          0          0 TTtimeClusterFinderUe
+TrigReport        131      20000      19786        214          0 tprHelixUeTCFilter
+TrigReport        131      19786      19786          0          0 TThelixFinderUe
+TrigReport        131      19786      19786          0          0 TTHelixMergerUe
+TrigReport        131      19786       1884      17902          0 tprHelixUeHSFilter
+TrigReport        131       1884       1884          0          0 tprHelixUeTriggerInfoMerger
 
 TrigReport ---------- Module summary ------------
 TrigReport    Visited        Run     Passed     Failed      Error Name
-TrigReport      22000       1000       1000          0          0 CaloClusterFast
-TrigReport      22000       1000       1000          0          0 CaloHitMakerFast
+TrigReport     440000      20000      20000          0          0 CaloClusterFast
+TrigReport     440000      20000      20000          0          0 CaloHitMakerFast
 TrigReport          0          0          0          0          0 CstLineFinder
 TrigReport          0          0          0          0          0 CstSimpleTimeCluster
-TrigReport       4005        801        801          0          0 TTAprHelixFinder
-TrigReport       4005        801        801          0          0 TTAprHelixMerger
-TrigReport         16         12         12          0          0 TTAprKSF
-TrigReport        348         87         87          0          0 TTCalHelixFinderDe
-TrigReport         78         78         78          0          0 TTCalHelixFinderUe
-TrigReport        348         87         87          0          0 TTCalHelixMergerDe
-TrigReport         78         78         78          0          0 TTCalHelixMergerUe
-TrigReport          4          4          4          0          0 TTCalSeedFitDe
-TrigReport       4000       1000       1000          0          0 TTCalTimePeakFinder
-TrigReport       1000       1000       1000          0          0 TTCalTimePeakFinderUe
-TrigReport      18000       1000       1000          0          0 TTDeltaFinder
-TrigReport       5958        998        998          0          0 TTHelixMergerDe
-TrigReport        991        991        991          0          0 TTHelixMergerUe
-TrigReport        188        101        101          0          0 TTKSFDe
-TrigReport        992        992        992          0          0 TTMprHelixMergerDe
-TrigReport        609        609        609          0          0 TTMprKSFDe
-TrigReport        992        992        992          0          0 TTRobustMultiHelixFinder
-TrigReport       5000       1000       1000          0          0 TTTZClusterFinder
-TrigReport       5958        998        998          0          0 TThelixFinder
-TrigReport        991        991        991          0          0 TThelixFinderUe
-TrigReport      18000       1000       1000          0          0 TTmakePH
-TrigReport      18000       1000       1000          0          0 TTmakeSH
-TrigReport       7000       1000       1000          0          0 TTtimeClusterFinder
-TrigReport       1000       1000       1000          0          0 TTtimeClusterFinderUe
-TrigReport        801        801         12        789          0 aprHelixHSFilter
-TrigReport       1000       1000        801        199          0 aprHelixTCFilter
-TrigReport         12         12         12          0          0 aprHelixTriggerInfoMerger
-TrigReport        801        801          9        792          0 aprHighPHSFilter
-TrigReport          9          9          0          9          0 aprHighPKSFilter
-TrigReport       1000       1000       1000          0          0 aprHighPPS
-TrigReport        801        801          1        800          0 aprHighPStopTargHSFilter
-TrigReport          1          1          0          1          0 aprHighPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 aprHighPStopTargPS
-TrigReport       1000       1000        801        199          0 aprHighPStopTargTCFilter
-TrigReport          0          0          0          0          0 aprHighPStopTargTriggerInfoMerger
-TrigReport       1000       1000        801        199          0 aprHighPTCFilter
-TrigReport          0          0          0          0          0 aprHighPTriggerInfoMerger
-TrigReport        801        801          6        795          0 aprLowPStopTargHSFilter
-TrigReport          6          6          0          6          0 aprLowPStopTargKSFilter
-TrigReport        801        801          0        801          0 aprLowPStopTargMultiTrkHSFilter
-TrigReport          0          0          0          0          0 aprLowPStopTargMultiTrkKSFilter
-TrigReport       1000       1000       1000          0          0 aprLowPStopTargMultiTrkPS
-TrigReport       1000       1000        801        199          0 aprLowPStopTargMultiTrkTCFilter
+TrigReport      80060      16012      16012          0          0 TTAprHelixFinder
+TrigReport      80060      16012      16012          0          0 TTAprHelixMerger
+TrigReport        518        304        304          0          0 TTAprKSF
+TrigReport       6316       1579       1579          0          0 TTCalHelixFinderDe
+TrigReport       1455       1455       1455          0          0 TTCalHelixFinderUe
+TrigReport       6316       1579       1579          0          0 TTCalHelixMergerDe
+TrigReport       1455       1455       1455          0          0 TTCalHelixMergerUe
+TrigReport        125         74         74          0          0 TTCalSeedFitDe
+TrigReport      80000      20000      20000          0          0 TTCalTimePeakFinder
+TrigReport      20000      20000      20000          0          0 TTCalTimePeakFinderUe
+TrigReport     360000      20000      20000          0          0 TTDeltaFinder
+TrigReport     118969      19904      19904          0          0 TTHelixMergerDe
+TrigReport      19786      19786      19786          0          0 TTHelixMergerUe
+TrigReport       3513       1850       1850          0          0 TTKSFDe
+TrigReport      19813      19813      19813          0          0 TTMprHelixMergerDe
+TrigReport      12188      12188      12188          0          0 TTMprKSFDe
+TrigReport      19813      19813      19813          0          0 TTRobustMultiHelixFinder
+TrigReport     100000      20000      20000          0          0 TTTZClusterFinder
+TrigReport     118969      19904      19904          0          0 TThelixFinder
+TrigReport      19786      19786      19786          0          0 TThelixFinderUe
+TrigReport     360000      20000      20000          0          0 TTmakePH
+TrigReport     360000      20000      20000          0          0 TTmakeSH
+TrigReport     140000      20000      20000          0          0 TTtimeClusterFinder
+TrigReport      20000      20000      20000          0          0 TTtimeClusterFinderUe
+TrigReport      16012      16012        304      15708          0 aprHelixHSFilter
+TrigReport      20000      20000      16012       3988          0 aprHelixTCFilter
+TrigReport        304        304        304          0          0 aprHelixTriggerInfoMerger
+TrigReport      16012      16012        234      15778          0 aprHighPHSFilter
+TrigReport        234        234          7        227          0 aprHighPKSFilter
+TrigReport      20000      20000      20000          0          0 aprHighPPS
+TrigReport      16012      16012         69      15943          0 aprHighPStopTargHSFilter
+TrigReport         69         69          5         64          0 aprHighPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 aprHighPStopTargPS
+TrigReport      20000      20000      16012       3988          0 aprHighPStopTargTCFilter
+TrigReport          5          5          5          0          0 aprHighPStopTargTriggerInfoMerger
+TrigReport      20000      20000      16012       3988          0 aprHighPTCFilter
+TrigReport          7          7          7          0          0 aprHighPTriggerInfoMerger
+TrigReport      16012      16012        211      15801          0 aprLowPStopTargHSFilter
+TrigReport        211        211         24        187          0 aprLowPStopTargKSFilter
+TrigReport      16012      16012          4      16008          0 aprLowPStopTargMultiTrkHSFilter
+TrigReport          4          4          0          4          0 aprLowPStopTargMultiTrkKSFilter
+TrigReport      20000      20000      20000          0          0 aprLowPStopTargMultiTrkPS
+TrigReport      20000      20000      16012       3988          0 aprLowPStopTargMultiTrkTCFilter
 TrigReport          0          0          0          0          0 aprLowPStopTargMultiTrkTriggerInfoMerger
-TrigReport       2000       1000       1000          0          0 aprLowPStopTargPS
-TrigReport       1000       1000        801        199          0 aprLowPStopTargTCFilter
-TrigReport          0          0          0          0          0 aprLowPStopTargTriggerInfoMerger
-TrigReport      27000       1000       1000          0          0 artFragFromDTCEvents
-TrigReport       1000       1000          0       1000          0 caloFastCosmicFilter
-TrigReport       1000       1000       1000          0          0 caloFastCosmicPS
-TrigReport       1000       1000         83        917          0 caloFastMVANNCEFilter
-TrigReport       1000       1000       1000          0          0 caloFastMVANNCEPS
-TrigReport       1000       1000         25        975          0 caloFastPhotonFilter
-TrigReport       1000       1000       1000          0          0 caloFastPhotonPS
-TrigReport       1000       1000          0       1000          0 caloFastRMCFilter
-TrigReport       1000       1000       1000          0          0 caloFastRMCPS
+TrigReport      40000      20000      20000          0          0 aprLowPStopTargPS
+TrigReport      20000      20000      16012       3988          0 aprLowPStopTargTCFilter
+TrigReport         24         24         24          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport     540000      20000      20000          0          0 artFragFromDTCEvents
+TrigReport      20000      20000          0      20000          0 caloFastCosmicFilter
+TrigReport      20000      20000      20000          0          0 caloFastCosmicPS
+TrigReport      20000      20000       1844      18156          0 caloFastMVANNCEFilter
+TrigReport      20000      20000      20000          0          0 caloFastMVANNCEPS
+TrigReport      20000      20000        471      19529          0 caloFastPhotonFilter
+TrigReport      20000      20000      20000          0          0 caloFastPhotonPS
+TrigReport      20000      20000          0      20000          0 caloFastRMCFilter
+TrigReport      20000      20000      20000          0          0 caloFastRMCPS
 TrigReport          0          0          0          0          0 caloHitRecN0SourceFilter
-TrigReport       1000       1000          0       1000          0 caloHitRecN0SourcePS
-TrigReport         87         87          1         86          0 cprDeHighPHSFilter
-TrigReport          1          1          0          1          0 cprDeHighPKSFilter
-TrigReport       1000       1000       1000          0          0 cprDeHighPPS
-TrigReport         87         87          0         87          0 cprDeHighPStopTargHSFilter
-TrigReport          0          0          0          0          0 cprDeHighPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 cprDeHighPStopTargPS
-TrigReport       1000       1000         87        913          0 cprDeHighPStopTargTCFilter
-TrigReport          0          0          0          0          0 cprDeHighPStopTargTriggerInfoMerger
-TrigReport       1000       1000         87        913          0 cprDeHighPTCFilter
-TrigReport          0          0          0          0          0 cprDeHighPTriggerInfoMerger
-TrigReport         87         87          3         84          0 cprDeLowPStopTargHSFilter
-TrigReport          3          3          0          3          0 cprDeLowPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 cprDeLowPStopTargPS
-TrigReport       1000       1000         87        913          0 cprDeLowPStopTargTCFilter
-TrigReport          0          0          0          0          0 cprDeLowPStopTargTriggerInfoMerger
-TrigReport         87         87          4         83          0 cprHelixDeHSFilter
-TrigReport       1000       1000       1000          0          0 cprHelixDePS
-TrigReport       1000       1000         87        913          0 cprHelixDeTCFilter
-TrigReport          4          4          4          0          0 cprHelixDeTriggerInfoMerger
-TrigReport         78         78          2         76          0 cprHelixUeHSFilter
-TrigReport       1000       1000       1000          0          0 cprHelixUePS
-TrigReport       1000       1000         78        922          0 cprHelixUeTCFilter
+TrigReport      20000      20000          0      20000          0 caloHitRecN0SourcePS
+TrigReport       1579       1579         38       1541          0 cprDeHighPHSFilter
+TrigReport         38         38          1         37          0 cprDeHighPKSFilter
+TrigReport      20000      20000      20000          0          0 cprDeHighPPS
+TrigReport       1579       1579         19       1560          0 cprDeHighPStopTargHSFilter
+TrigReport         19         19          1         18          0 cprDeHighPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 cprDeHighPStopTargPS
+TrigReport      20000      20000       1579      18421          0 cprDeHighPStopTargTCFilter
+TrigReport          1          1          1          0          0 cprDeHighPStopTargTriggerInfoMerger
+TrigReport      20000      20000       1579      18421          0 cprDeHighPTCFilter
+TrigReport          1          1          1          0          0 cprDeHighPTriggerInfoMerger
+TrigReport       1579       1579         68       1511          0 cprDeLowPStopTargHSFilter
+TrigReport         68         68         20         48          0 cprDeLowPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 cprDeLowPStopTargPS
+TrigReport      20000      20000       1579      18421          0 cprDeLowPStopTargTCFilter
+TrigReport         20         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport       1579       1579         72       1507          0 cprHelixDeHSFilter
+TrigReport      20000      20000      20000          0          0 cprHelixDePS
+TrigReport      20000      20000       1579      18421          0 cprHelixDeTCFilter
+TrigReport         72         72         72          0          0 cprHelixDeTriggerInfoMerger
+TrigReport       1455       1455         28       1427          0 cprHelixUeHSFilter
+TrigReport      20000      20000      20000          0          0 cprHelixUePS
+TrigReport      20000      20000       1455      18545          0 cprHelixUeTCFilter
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedCTSFilter
-TrigReport       1000       1000          0       1000          0 cstCosmicTrackSeedPS
+TrigReport      20000      20000          0      20000          0 cstCosmicTrackSeedPS
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedSDCountFilter
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedTCFilter
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedTriggerInfoMerger
-TrigReport       1000       1000          0       1000          0 cstTimeClusterPS
+TrigReport      20000      20000          0      20000          0 cstTimeClusterPS
 TrigReport          0          0          0          0          0 cstTimeClusterSDCountFilter
 TrigReport          0          0          0          0          0 cstTimeClusterTCFilter
 TrigReport          0          0          0          0          0 cstTimeClusterTriggerInfoMerger
 TrigReport          0          0          0          0          0 minBiasCDCountFilter
-TrigReport       1000       1000          0       1000          0 minBiasCDCountPS
+TrigReport      20000      20000          0      20000          0 minBiasCDCountPS
 TrigReport          0          0          0          0          0 minBiasSDCountFilter
-TrigReport       1000       1000          0       1000          0 minBiasSDCountPS
-TrigReport        992        992        609        383          0 mprDeHighPStopTargHSFilter
-TrigReport        609        609         17        592          0 mprDeHighPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 mprDeHighPStopTargPS
-TrigReport       1000       1000        992          8          0 mprDeHighPStopTargTCFilter
-TrigReport         17         17         17          0          0 mprDeHighPStopTargTriggerInfoMerger
-TrigReport        992        992         57        935          0 tprDeHighPHSFilter
-TrigReport         57         57          0         57          0 tprDeHighPKSFilter
-TrigReport       1000       1000       1000          0          0 tprDeHighPPS
-TrigReport        992        992         35        957          0 tprDeHighPStopTargHSFilter
-TrigReport         35         35          0         35          0 tprDeHighPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 tprDeHighPStopTargPS
-TrigReport       1000       1000        992          8          0 tprDeHighPStopTargTCFilter
+TrigReport      20000      20000          0      20000          0 minBiasSDCountPS
+TrigReport      19813      19813      12188       7625          0 mprDeHighPStopTargHSFilter
+TrigReport      12188      12188        268      11920          0 mprDeHighPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 mprDeHighPStopTargPS
+TrigReport      20000      20000      19813        187          0 mprDeHighPStopTargTCFilter
+TrigReport        268        268        268          0          0 mprDeHighPStopTargTriggerInfoMerger
+TrigReport      19813      19813       1089      18724          0 tprDeHighPHSFilter
+TrigReport       1089       1089          4       1085          0 tprDeHighPKSFilter
+TrigReport      20000      20000      20000          0          0 tprDeHighPPS
+TrigReport      19813      19813        695      19118          0 tprDeHighPStopTargHSFilter
+TrigReport        695        695          0        695          0 tprDeHighPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 tprDeHighPStopTargPS
+TrigReport      20000      20000      19813        187          0 tprDeHighPStopTargTCFilter
 TrigReport          0          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
-TrigReport       1000       1000        992          8          0 tprDeHighPTCFilter
-TrigReport          0          0          0          0          0 tprDeHighPTriggerInfoMerger
-TrigReport        998        998         96        902          0 tprDeLowPStopTargHSFilter
-TrigReport         96         96         11         85          0 tprDeLowPStopTargKSFilter
-TrigReport       1000       1000       1000          0          0 tprDeLowPStopTargPS
-TrigReport       1000       1000        998          2          0 tprDeLowPStopTargTCFilter
-TrigReport         11         11         11          0          0 tprDeLowPStopTargTriggerInfoMerger
-TrigReport        992        992         74        918          0 tprHelixDeHSFilter
-TrigReport        992        992         29        963          0 tprHelixDeIpaHSFilter
-TrigReport       1000       1000       1000          0          0 tprHelixDeIpaPS
-TrigReport        992        992          7        985          0 tprHelixDeIpaPhiScaledHSFilter
-TrigReport       1000       1000       1000          0          0 tprHelixDeIpaPhiScaledPS
-TrigReport       1000       1000        992          8          0 tprHelixDeIpaPhiScaledTCFilter
-TrigReport          7          7          7          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
-TrigReport       1000       1000        992          8          0 tprHelixDeIpaTCFilter
-TrigReport         29         29         29          0          0 tprHelixDeIpaTriggerInfoMerger
-TrigReport       1000       1000       1000          0          0 tprHelixDePS
-TrigReport       1000       1000        992          8          0 tprHelixDeTCFilter
-TrigReport         74         74         74          0          0 tprHelixDeTriggerInfoMerger
-TrigReport        991        991         90        901          0 tprHelixUeHSFilter
-TrigReport       1000       1000       1000          0          0 tprHelixUePS
-TrigReport       1000       1000        991          9          0 tprHelixUeTCFilter
-TrigReport         90         90         90          0          0 tprHelixUeTriggerInfoMerger
+TrigReport      20000      20000      19813        187          0 tprDeHighPTCFilter
+TrigReport          4          4          4          0          0 tprDeHighPTriggerInfoMerger
+TrigReport      19904      19904       1729      18175          0 tprDeLowPStopTargHSFilter
+TrigReport       1729       1729        166       1563          0 tprDeLowPStopTargKSFilter
+TrigReport      20000      20000      20000          0          0 tprDeLowPStopTargPS
+TrigReport      20000      20000      19904         96          0 tprDeLowPStopTargTCFilter
+TrigReport        166        166        166          0          0 tprDeLowPStopTargTriggerInfoMerger
+TrigReport      19813      19813       1413      18400          0 tprHelixDeHSFilter
+TrigReport      19813      19813        543      19270          0 tprHelixDeIpaHSFilter
+TrigReport      20000      20000      20000          0          0 tprHelixDeIpaPS
+TrigReport      19813      19813        139      19674          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport      20000      20000      20000          0          0 tprHelixDeIpaPhiScaledPS
+TrigReport      20000      20000      19813        187          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport        139        139        139          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+TrigReport      20000      20000      19813        187          0 tprHelixDeIpaTCFilter
+TrigReport        543        543        543          0          0 tprHelixDeIpaTriggerInfoMerger
+TrigReport      20000      20000      20000          0          0 tprHelixDePS
+TrigReport      20000      20000      19813        187          0 tprHelixDeTCFilter
+TrigReport       1413       1413       1413          0          0 tprHelixDeTriggerInfoMerger
+TrigReport      19786      19786       1884      17902          0 tprHelixUeHSFilter
+TrigReport      20000      20000      20000          0          0 tprHelixUePS
+TrigReport      20000      20000      19786        214          0 tprHelixUeTCFilter
+TrigReport       1884       1884       1884          0          0 tprHelixUeTriggerInfoMerger
 
 TimeReport ---------- Time summary [sec] -------
-TimeReport CPU = 17.766824 Real = 18.293343
+TimeReport CPU = 342.813796 Real = 375.424363
 
 MemReport  ---------- Memory summary [base-10 MB] ------
-MemReport  VmPeak = 1496.87 VmHWM = 571.617
+MemReport  VmPeak = 1524.16 VmHWM = 573.788
 
 Art has completed and will exit with status 0.

--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,0 +1,760 @@
+   ************************** Mu2e Offline **************************
+     art v3_14_03    root v6_30_04    KinKal v03_01_05
+     build  /exp/mu2e/app/users/mmackenz/Yale/main
+     build  al9-prof-e28-p066    01/03/25 12:53:22
+   ******************************************************************
+Conditions file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/ConditionsService/data/conditions_01.txt
+Conditions lines: 38  hash: 8098310628555253397
+DbService  MDC2020_best v1_3   mu2e_conditions_prd
+DbService  textFiles: 
+GlobalConstants file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/GlobalConstantsService/data/globalConstants_01.txt
+GlobalConstants lines: 165  hash: 10185786924093877558
+BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
+BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
+DeltaFinderAlg created
+BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
+BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
+06-Jan-2025 16:14:59 CST  Initiating request to open input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
+06-Jan-2025 16:14:59 CST  Opened input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
+tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
+tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
+Geometry file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/geom_common.txt
+Geometry lines: 20795  hash: 8400552694993792382
+BField file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
+BField lines: 98  hash: 3243269116804334601
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 06-Jan-2025 16:14:59 CST
+DbReader::fillValCache took 0.323606 s
+DbEngine confirmed purpose and version:
+MDC2020_best 1/3/-1
+DbEngine IoV summary
+            Table        N IoV
+       TrkDelayPanel       1
+      TrkPreampStraw       1
+     TrkAlignTracker       1
+       TrkAlignPlane       1
+       TrkAlignPanel       1
+       TrkAlignStraw       1
+      TrkPanelStatus       1
+      TrkPlaneStatus       1
+ TrkStrawStatusShort       1
+  TrkStrawStatusLong       1
+      TrkDelayRStraw       1
+    SimEfficiencies2       1
+  TrkAlignTrackerSim       1
+    TrkAlignPlaneSim       1
+    TrkAlignPanelSim       1
+    TrkAlignStrawSim       1
+          CRVBadChan       3
+             CRVSiPM       3
+           CRVPhoton       3
+             CRVTime       3
+DbEngine inclusive beginJob time was 0.323854 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 06-Jan-2025 16:15:00 CST
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 06-Jan-2025 16:15:00 CST
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 06-Jan-2025 16:15:00 CST
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 06-Jan-2025 16:15:00 CST
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 06-Jan-2025 16:15:01 CST
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 06-Jan-2025 16:15:01 CST
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 06-Jan-2025 16:15:02 CST
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 06-Jan-2025 16:15:02 CST
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 06-Jan-2025 16:15:04 CST
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 06-Jan-2025 16:15:09 CST
+06-Jan-2025 16:15:17 CST  Closed input file "/exp/mu2e/data/users/gianipez/data/skim_NoPRimary1BB_1.art"
+
+=======================================================================================================================================================================
+TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
+=======================================================================================================================================================================
+Full event                                                                           0.00110845     0.0173603     0.907858      0.0088097     0.0353873      1000    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+source:RootInput(read)                                                               6.5605e-05    0.000108049   0.000427868   9.7265e-05    3.87906e-05     1000    
+caloHitRec_N0Source:artFragFromDTCEvents:ArtFragmentsFromDTCEvents                   1.0761e-05    1.42928e-05   0.000184151   1.2563e-05    7.23129e-06     1000    
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.777e-06    1.28268e-05   0.000288021    1.059e-05    1.03366e-05     1000    
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.914e-06    2.63398e-06   2.0589e-05     2.375e-06    1.05498e-06     1000    
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.623e-06    2.15972e-06   2.0449e-05     1.943e-06    1.13537e-06     1000    
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.593e-06    2.09237e-06   1.8055e-05     1.843e-06    1.12211e-06     1000    
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.463e-06    1.98669e-06   2.1552e-05     1.733e-06    1.27574e-06     1000    
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.583e-06    2.04638e-06   1.9958e-05     1.803e-06    1.20769e-06     1000    
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       9.0733e-05    0.000464751   0.00210494    0.000381158   0.000287386     1000    
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                         1.1351e-05    6.20738e-05   0.000294873   5.1974e-05    3.90304e-05     1000    
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.673e-06    8.75506e-06   8.4862e-05    7.8395e-06    4.20389e-06     1000    
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.505e-06    3.38418e-06   1.9327e-05    3.1555e-06    1.23426e-06     1000    
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.418e-06    5.72033e-06    3.11e-05      5.13e-06     2.13265e-06     1000    
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.663e-06    2.16663e-06   2.2944e-05     1.934e-06    1.03365e-06     1000    
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.07e-06     7.98893e-06   0.000208719    7.034e-06    7.13665e-06     1000    
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.683e-06    2.30817e-06   2.5489e-05     1.954e-06    1.55212e-06     1000    
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.039e-06    8.15326e-06   0.000191296    5.987e-06    7.45006e-06     1000    
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.773e-06    2.46371e-06   3.8234e-05     2.154e-06    1.71906e-06     1000    
+aprHelix:TTmakeSH:StrawHitReco                                                       6.5876e-05    0.00129934     0.895092     0.000346918    0.0282794      1000    
+aprHelix:TTmakePH:CombineStrawHits                                                   1.1292e-05    6.38135e-05   0.00131839    4.9515e-05    6.1595e-05      1000    
+aprHelix:TTDeltaFinder:DeltaFinder                                                    8.374e-05    0.00039699     0.0030477    0.000293351   0.000327888     1000    
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.3485e-05    6.60543e-05   0.00043955    4.9685e-05    5.22983e-05     1000    
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                          1.0079e-05    1.33135e-05   4.5898e-05    1.22335e-05   3.69226e-06     1000    
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.1522e-05    0.000407635    0.0064413    0.000132363   0.000692865      801    
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1452e-05    1.44245e-05   4.8192e-05    1.3215e-05    3.70607e-06      801    
+aprHelix:aprHelixHSFilter:HelixFilter                                                 6.052e-06    7.89026e-06   3.4326e-05     7.074e-06     2.741e-06       801    
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkPS:PrescaleEvent                    2.464e-06    3.4228e-06    1.8286e-05     3.126e-06    1.37938e-06     1000    
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkTCFilter:TimeClusterFilter          7.695e-06    1.02042e-05   4.5928e-05    9.3675e-06    3.11454e-06     1000    
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkHSFilter:HelixFilter                5.51e-06     6.77206e-06   7.7779e-05     6.101e-06    3.29799e-06      801    
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.793e-06    8.45163e-06   3.5788e-05    7.7755e-06    2.51122e-06     1000    
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 5.009e-06    6.11883e-06   2.8454e-05     5.52e-06     2.03981e-06      801    
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.693e-06    2.35619e-06   1.6561e-05     2.104e-06    1.0177e-06      1000    
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.161e-06    7.82703e-06   4.4554e-05     6.974e-06    2.85965e-06     1000    
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.648e-06    5.91161e-06   2.3706e-05     5.27e-06     2.20498e-06      801    
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.663e-06    2.22821e-06   2.1842e-05     1.954e-06    1.26347e-06     1000    
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.242e-06    8.09636e-06   0.000176417    6.983e-06    7.80076e-06     1000    
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.689e-06    5.78776e-06   2.5078e-05     5.16e-06     2.09245e-06      801    
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.724e-06    2.26169e-06   2.2844e-05     2.024e-06    1.04158e-06     1000    
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.235e-06    1.24517e-05   0.000174704    9.584e-06    8.57456e-06     1000    
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       6.965e-06    8.50049e-06   3.2352e-05     7.795e-06    2.42035e-06     1000    
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.733e-06    2.39985e-06   1.6902e-05     2.074e-06    1.34595e-06     1000    
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.402e-06    9.35982e-06   7.3261e-05    7.0535e-06    6.19305e-06     1000    
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.492e-06    8.04912e-06   4.5778e-05    7.0845e-06    3.24728e-06     1000    
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.723e-06    2.31009e-06   1.8064e-05     2.014e-06    1.08723e-06     1000    
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.292e-06    8.21988e-06    0.0001881     6.983e-06    7.39659e-06     1000    
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.643e-06    2.18298e-06   1.7062e-05     1.934e-06    1.0048e-06      1000    
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.402e-06    7.88623e-06    3.667e-05     7.053e-06    2.78627e-06     1000    
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.673e-06    2.1107e-06    1.8155e-05     1.903e-06    9.71179e-07     1000    
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.012e-06    7.37911e-06    3.104e-05    6.6025e-06    2.60983e-06     1000    
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.723e-06    2.26823e-06   2.0248e-05    1.9935e-06    1.15464e-06     1000    
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                    3.099e-05    0.00147458     0.0154486    0.000856563   0.00176584      1000    
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.995e-06    1.2513e-05    6.7329e-05    1.16675e-05   4.10474e-06     1000    
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                         1.0671e-05    0.000296273   0.00752643    0.000134697   0.000498935      991    
+tprHelixUe:TTHelixMergerUe:MergeHelices                                               9.889e-06    1.64416e-05   0.000186958   1.4116e-05    8.57044e-06      991    
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.641e-06    8.56641e-06   3.5577e-05     7.394e-06    2.97867e-06      991    
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.944e-06    3.13306e-06   2.2262e-05     2.936e-06    1.27356e-06     1000    
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.7743e-05    0.00139829     0.0162024    0.000801252    0.0017563      1000    
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.053e-06    1.28527e-05   5.6017e-05    1.1882e-05    4.53564e-06     1000    
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.556e-06    0.000312701   0.00521219    0.000137518   0.000474908      992    
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.198e-06    1.55476e-05   6.1988e-05    1.3376e-05    6.2438e-06       992    
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.26e-06     8.58872e-06    3.676e-05     7.409e-06    3.41728e-06      992    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.834e-06    3.15698e-06    1.509e-05    2.9855e-06    1.09642e-06     1000    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.372e-06    1.00849e-05   2.7512e-05     9.538e-06    2.80802e-06     1000    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.638e-06    6.5764e-06    4.6359e-05     5.656e-06    2.61801e-06      992    
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.674e-06    2.33836e-06   6.3842e-05    2.0945e-06    2.09454e-06     1000    
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.383e-06    8.61075e-06   0.000174665    7.686e-06    6.02922e-06     1000    
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.538e-06    6.13794e-06   2.8605e-05    5.2795e-06    2.34682e-06      992    
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.714e-06    2.25283e-06   2.1752e-05    1.9885e-06    1.14214e-06     1000    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.302e-06    8.47904e-06   0.000142522    7.514e-06    5.95321e-06     1000    
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.729e-06    6.57655e-06   3.3324e-05     5.701e-06    2.64505e-06      998    
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.783e-06    2.46066e-06   1.7874e-05     2.094e-06    1.18162e-06     1000    
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.162e-06    8.28618e-06   3.9255e-05    7.1035e-06    3.21827e-06     1000    
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.588e-06    6.52356e-06   2.4035e-05    5.3655e-06    2.65645e-06      992    
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.643e-06    2.20799e-06   2.0089e-05     1.924e-06    1.33814e-06     1000    
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.372e-06    8.27972e-06   4.2581e-05    7.2835e-06    3.16318e-06     1000    
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.708e-06    6.43358e-06    2.607e-05     5.52e-06     2.35932e-06      992    
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.593e-06    2.05615e-06   1.6733e-05     1.833e-06    9.52501e-07     1000    
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.562e-06     8.784e-06    0.000219359   7.4895e-06    1.1129e-05      1000    
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.9137e-05    0.00351343     0.153802     0.00109403    0.00890585       992    
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2995e-05    0.000165305   0.00314605    4.5993e-05    0.000329363      992    
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.321e-06    2.22506e-05   0.000174724   1.7594e-05     1.67e-05        992    
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000243445    0.0102761     0.0537748    0.00753361    0.00884734       609    
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.776e-06    1.88415e-05    7.834e-05    1.6361e-05    8.7142e-06       609    
+[art]:TriggerResults:TriggerResultInserter                                            3.647e-06    4.88636e-06   2.2904e-05     4.128e-06    2.18047e-06     1000    
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         6.0316e-05    0.000224069   0.00115532    0.000168372   0.000193785      78     
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.0941e-05    1.44958e-05   2.6932e-05    1.3195e-05    3.38694e-06      78     
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.921e-06    8.04856e-06   1.5099e-05    7.2935e-06    2.04284e-06      78     
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.9925e-05    0.000209068   0.000722502   0.000159035   0.000157976      87     
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                           1.0129e-05    1.42497e-05   3.6579e-05    1.2834e-05    4.75149e-06      87     
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.471e-06    7.88856e-06    1.612e-05     7.094e-06    2.12144e-06      87     
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.24e-06     7.58554e-06   3.0939e-05     6.422e-06    3.52226e-06      87     
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.119e-06    7.00451e-06   2.1812e-05     6.303e-06    2.42716e-06      87     
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.28e-06     6.93884e-06   1.3425e-05     6.313e-06    1.47818e-06      87     
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.2904e-05    2.05254e-05   0.000130359   1.6236e-05    1.42488e-05      74     
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000285445   0.00168923    0.00562702    0.00140481    0.00101556       96     
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.606e-06    1.30412e-05    2.586e-05    1.24235e-05   3.31302e-06      96     
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.5611e-05    1.74982e-05   1.9728e-05    1.7364e-05    1.09139e-06      11     
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.4627e-05    2.27357e-05   5.2089e-05    2.21425e-05   6.66089e-06      90     
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.609e-06    7.85923e-06   2.2544e-05     7.124e-06    3.20215e-06      57     
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.949e-06    6.84169e-06   1.1742e-05     6.682e-06    1.54154e-06      35     
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.4739e-05    2.14503e-05   2.8685e-05    2.3014e-05    4.61977e-06      12     
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.000214139   0.00067591    0.00137286    0.000565791   0.000432569       6     
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.25e-06     9.83533e-06    1.605e-05    1.1171e-05    3.53427e-06       9     
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        9.678e-06    1.46554e-05   2.3796e-05    1.4298e-05    3.36307e-06      29     
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.769e-06    5.01627e-05   0.000195434   1.36265e-05   6.7058e-05        6     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                      1.105e-05    1.25452e-05   1.4167e-05    1.2503e-05    9.18684e-07       6     
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7393e-05    2.77299e-05   4.8453e-05    2.3665e-05    1.0131e-05       17     
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.6241e-05    3.48093e-05   8.1426e-05    2.0785e-05    2.69784e-05       4     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000195634   0.000195634   0.000195634   0.000195634        0            1     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                         1.1032e-05    1.1032e-05    1.1032e-05    1.1032e-05         0            1     
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000343677    0.0013041     0.0026438    0.00101068    0.000769378       5     
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1882e-05    2.34079e-05    7.306e-05     1.539e-05    2.05998e-05       7     
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000163062   0.000434364   0.00094693    0.000275106   0.000304708       6     
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               8.145e-06    1.03915e-05    1.555e-05    9.6885e-06    2.48443e-06       6     
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000201344   0.000990734   0.00239339    0.000377472   0.000994427       3     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           9.078e-06    1.10347e-05   1.4488e-05     9.538e-06    2.44909e-06       3     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.52e-06      5.52e-06      5.52e-06      5.52e-06          0            1     
+=======================================================================================================================================================================
+DbEngine::endJob
+    Total time in reading DB: 0.816342 s
+    Total time waiting for locks: 1e-06 s
+    Total time in locks: 0.562874 s
+    valcache memory: 58065 b
+  Database cache stats:
+    cache nTable : 11
+    cache HWM    : 1364957 b
+    cache nPurges : 0
+    cache nPurged : 0
+
+TrigReport ---------- Event summary -------------
+TrigReport Events total = 1000 passed = 216 failed = 784
+
+TrigReport ---------- Trigger-path summary ------------
+TrigReport    Path ID        Run     Passed     Failed      Error Name
+TrigReport        100       1000          0       1000          0 tprDe_highP_stopTarg
+TrigReport        101       1000          0       1000          0 tprDe_highP
+TrigReport        110       1000         11        989          0 tprDe_lowP_stopTarg
+TrigReport        120       1000         29        971          0 tprHelixDe_ipa
+TrigReport        121       1000          7        993          0 tprHelixDe_ipa_phiScaled
+TrigReport        130       1000         74        926          0 tprHelixDe
+TrigReport        131       1000         90        910          0 tprHelixUe
+TrigReport        150       1000          0       1000          0 cprDe_highP_stopTarg
+TrigReport        151       1000          0       1000          0 cprDe_highP
+TrigReport        160       1000          0       1000          0 cprDe_lowP_stopTarg
+TrigReport        170       1000          4        996          0 cprHelixDe
+TrigReport        171       1000          2        998          0 cprHelixUe
+TrigReport        180       1000          0       1000          0 apr_highP_stopTarg
+TrigReport        181       1000          0       1000          0 apr_highP
+TrigReport        190       1000          0       1000          0 apr_lowP_stopTarg
+TrigReport        191       1000          0       1000          0 apr_lowP_stopTarg_multiTrk
+TrigReport        195       1000         12        988          0 aprHelix
+TrigReport        200       1000         25        975          0 caloFast_photon
+TrigReport        201       1000         83        917          0 caloFast_MVANNCE
+TrigReport        202       1000          0       1000          0 caloFast_cosmic
+TrigReport        210       1000         17        983          0 mprDe_highP_stopTarg
+TrigReport        220       1000          0       1000          0 caloFast_RMC
+TrigReport        310       1000          0       1000          0 cstTimeCluster
+TrigReport        320       1000          0       1000          0 cstCosmicTrackSeed
+TrigReport        400       1000          0       1000          0 minBias_SDCount
+TrigReport        410       1000          0       1000          0 minBias_CDCount
+TrigReport        500       1000          0       1000          0 caloHitRec_N0Source
+
+TrigReport ---------- End-path summary ---------
+TrigReport        Run    Success      Error
+
+TrigReport ---------- Modules in path: aprHelix ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        195       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        195       1000       1000          0          0 aprLowPStopTargPS
+TrigReport        195       1000       1000          0          0 CaloHitMakerFast
+TrigReport        195       1000       1000          0          0 CaloClusterFast
+TrigReport        195       1000       1000          0          0 TTmakeSH
+TrigReport        195       1000       1000          0          0 TTmakePH
+TrigReport        195       1000       1000          0          0 TTDeltaFinder
+TrigReport        195       1000       1000          0          0 TTTZClusterFinder
+TrigReport        195       1000        801        199          0 aprHelixTCFilter
+TrigReport        195        801        801          0          0 TTAprHelixFinder
+TrigReport        195        801        801          0          0 TTAprHelixMerger
+TrigReport        195        801         12        789          0 aprHelixHSFilter
+TrigReport        195         12         12          0          0 aprHelixTriggerInfoMerger
+
+TrigReport ---------- Modules in path: apr_highP ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        181       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        181       1000       1000          0          0 aprHighPPS
+TrigReport        181       1000       1000          0          0 CaloHitMakerFast
+TrigReport        181       1000       1000          0          0 CaloClusterFast
+TrigReport        181       1000       1000          0          0 TTmakeSH
+TrigReport        181       1000       1000          0          0 TTmakePH
+TrigReport        181       1000       1000          0          0 TTDeltaFinder
+TrigReport        181       1000       1000          0          0 TTTZClusterFinder
+TrigReport        181       1000        801        199          0 aprHighPTCFilter
+TrigReport        181        801        801          0          0 TTAprHelixFinder
+TrigReport        181        801        801          0          0 TTAprHelixMerger
+TrigReport        181        801          9        792          0 aprHighPHSFilter
+TrigReport        181          9          9          0          0 TTAprKSF
+TrigReport        181          9          0          9          0 aprHighPKSFilter
+TrigReport        181          0          0          0          0 aprHighPTriggerInfoMerger
+
+TrigReport ---------- Modules in path: apr_highP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        180       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        180       1000       1000          0          0 aprHighPStopTargPS
+TrigReport        180       1000       1000          0          0 CaloHitMakerFast
+TrigReport        180       1000       1000          0          0 CaloClusterFast
+TrigReport        180       1000       1000          0          0 TTmakeSH
+TrigReport        180       1000       1000          0          0 TTmakePH
+TrigReport        180       1000       1000          0          0 TTDeltaFinder
+TrigReport        180       1000       1000          0          0 TTTZClusterFinder
+TrigReport        180       1000        801        199          0 aprHighPStopTargTCFilter
+TrigReport        180        801        801          0          0 TTAprHelixFinder
+TrigReport        180        801        801          0          0 TTAprHelixMerger
+TrigReport        180        801          1        800          0 aprHighPStopTargHSFilter
+TrigReport        180          1          1          0          0 TTAprKSF
+TrigReport        180          1          0          1          0 aprHighPStopTargKSFilter
+TrigReport        180          0          0          0          0 aprHighPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: apr_lowP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        190       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        190       1000       1000          0          0 aprLowPStopTargPS
+TrigReport        190       1000       1000          0          0 CaloHitMakerFast
+TrigReport        190       1000       1000          0          0 CaloClusterFast
+TrigReport        190       1000       1000          0          0 TTmakeSH
+TrigReport        190       1000       1000          0          0 TTmakePH
+TrigReport        190       1000       1000          0          0 TTDeltaFinder
+TrigReport        190       1000       1000          0          0 TTTZClusterFinder
+TrigReport        190       1000        801        199          0 aprLowPStopTargTCFilter
+TrigReport        190        801        801          0          0 TTAprHelixFinder
+TrigReport        190        801        801          0          0 TTAprHelixMerger
+TrigReport        190        801          6        795          0 aprLowPStopTargHSFilter
+TrigReport        190          6          6          0          0 TTAprKSF
+TrigReport        190          6          0          6          0 aprLowPStopTargKSFilter
+TrigReport        190          0          0          0          0 aprLowPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: apr_lowP_stopTarg_multiTrk ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        191       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        191       1000       1000          0          0 aprLowPStopTargMultiTrkPS
+TrigReport        191       1000       1000          0          0 CaloHitMakerFast
+TrigReport        191       1000       1000          0          0 CaloClusterFast
+TrigReport        191       1000       1000          0          0 TTmakeSH
+TrigReport        191       1000       1000          0          0 TTmakePH
+TrigReport        191       1000       1000          0          0 TTDeltaFinder
+TrigReport        191       1000       1000          0          0 TTTZClusterFinder
+TrigReport        191       1000        801        199          0 aprLowPStopTargMultiTrkTCFilter
+TrigReport        191        801        801          0          0 TTAprHelixFinder
+TrigReport        191        801        801          0          0 TTAprHelixMerger
+TrigReport        191        801          0        801          0 aprLowPStopTargMultiTrkHSFilter
+TrigReport        191          0          0          0          0 TTAprKSF
+TrigReport        191          0          0          0          0 aprLowPStopTargMultiTrkKSFilter
+TrigReport        191          0          0          0          0 aprLowPStopTargMultiTrkTriggerInfoMerger
+
+TrigReport ---------- Modules in path: caloFast_MVANNCE ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        201       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        201       1000       1000          0          0 caloFastMVANNCEPS
+TrigReport        201       1000       1000          0          0 CaloHitMakerFast
+TrigReport        201       1000       1000          0          0 CaloClusterFast
+TrigReport        201       1000         83        917          0 caloFastMVANNCEFilter
+
+TrigReport ---------- Modules in path: caloFast_RMC ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        220       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        220       1000       1000          0          0 caloFastRMCPS
+TrigReport        220       1000       1000          0          0 CaloHitMakerFast
+TrigReport        220       1000       1000          0          0 CaloClusterFast
+TrigReport        220       1000          0       1000          0 caloFastRMCFilter
+
+TrigReport ---------- Modules in path: caloFast_cosmic ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        202       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        202       1000       1000          0          0 caloFastCosmicPS
+TrigReport        202       1000       1000          0          0 CaloHitMakerFast
+TrigReport        202       1000       1000          0          0 CaloClusterFast
+TrigReport        202       1000          0       1000          0 caloFastCosmicFilter
+
+TrigReport ---------- Modules in path: caloFast_photon ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        200       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        200       1000       1000          0          0 caloFastPhotonPS
+TrigReport        200       1000       1000          0          0 CaloHitMakerFast
+TrigReport        200       1000       1000          0          0 CaloClusterFast
+TrigReport        200       1000         25        975          0 caloFastPhotonFilter
+
+TrigReport ---------- Modules in path: caloHitRec_N0Source ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        500       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        500       1000          0       1000          0 caloHitRecN0SourcePS
+TrigReport        500          0          0          0          0 CaloHitMakerFast
+TrigReport        500          0          0          0          0 caloHitRecN0SourceFilter
+
+TrigReport ---------- Modules in path: cprDe_highP ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        151       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        151       1000       1000          0          0 cprDeHighPPS
+TrigReport        151       1000       1000          0          0 CaloHitMakerFast
+TrigReport        151       1000       1000          0          0 CaloClusterFast
+TrigReport        151       1000       1000          0          0 TTmakeSH
+TrigReport        151       1000       1000          0          0 TTmakePH
+TrigReport        151       1000       1000          0          0 TTDeltaFinder
+TrigReport        151       1000       1000          0          0 TTCalTimePeakFinder
+TrigReport        151       1000         87        913          0 cprDeHighPTCFilter
+TrigReport        151         87         87          0          0 TTCalHelixFinderDe
+TrigReport        151         87         87          0          0 TTCalHelixMergerDe
+TrigReport        151         87          1         86          0 cprDeHighPHSFilter
+TrigReport        151          1          1          0          0 TTCalSeedFitDe
+TrigReport        151          1          0          1          0 cprDeHighPKSFilter
+TrigReport        151          0          0          0          0 cprDeHighPTriggerInfoMerger
+
+TrigReport ---------- Modules in path: cprDe_highP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        150       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        150       1000       1000          0          0 cprDeHighPStopTargPS
+TrigReport        150       1000       1000          0          0 CaloHitMakerFast
+TrigReport        150       1000       1000          0          0 CaloClusterFast
+TrigReport        150       1000       1000          0          0 TTmakeSH
+TrigReport        150       1000       1000          0          0 TTmakePH
+TrigReport        150       1000       1000          0          0 TTDeltaFinder
+TrigReport        150       1000       1000          0          0 TTCalTimePeakFinder
+TrigReport        150       1000         87        913          0 cprDeHighPStopTargTCFilter
+TrigReport        150         87         87          0          0 TTCalHelixFinderDe
+TrigReport        150         87         87          0          0 TTCalHelixMergerDe
+TrigReport        150         87          0         87          0 cprDeHighPStopTargHSFilter
+TrigReport        150          0          0          0          0 TTCalSeedFitDe
+TrigReport        150          0          0          0          0 cprDeHighPStopTargKSFilter
+TrigReport        150          0          0          0          0 cprDeHighPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: cprDe_lowP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        160       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        160       1000       1000          0          0 cprDeLowPStopTargPS
+TrigReport        160       1000       1000          0          0 CaloHitMakerFast
+TrigReport        160       1000       1000          0          0 CaloClusterFast
+TrigReport        160       1000       1000          0          0 TTmakeSH
+TrigReport        160       1000       1000          0          0 TTmakePH
+TrigReport        160       1000       1000          0          0 TTDeltaFinder
+TrigReport        160       1000       1000          0          0 TTCalTimePeakFinder
+TrigReport        160       1000         87        913          0 cprDeLowPStopTargTCFilter
+TrigReport        160         87         87          0          0 TTCalHelixFinderDe
+TrigReport        160         87         87          0          0 TTCalHelixMergerDe
+TrigReport        160         87          3         84          0 cprDeLowPStopTargHSFilter
+TrigReport        160          3          3          0          0 TTCalSeedFitDe
+TrigReport        160          3          0          3          0 cprDeLowPStopTargKSFilter
+TrigReport        160          0          0          0          0 cprDeLowPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: cprHelixDe ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        170       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        170       1000       1000          0          0 cprHelixDePS
+TrigReport        170       1000       1000          0          0 CaloHitMakerFast
+TrigReport        170       1000       1000          0          0 CaloClusterFast
+TrigReport        170       1000       1000          0          0 TTmakeSH
+TrigReport        170       1000       1000          0          0 TTmakePH
+TrigReport        170       1000       1000          0          0 TTDeltaFinder
+TrigReport        170       1000       1000          0          0 TTCalTimePeakFinder
+TrigReport        170       1000         87        913          0 cprHelixDeTCFilter
+TrigReport        170         87         87          0          0 TTCalHelixFinderDe
+TrigReport        170         87         87          0          0 TTCalHelixMergerDe
+TrigReport        170         87          4         83          0 cprHelixDeHSFilter
+TrigReport        170          4          4          0          0 cprHelixDeTriggerInfoMerger
+
+TrigReport ---------- Modules in path: cprHelixUe ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        171       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        171       1000       1000          0          0 cprHelixUePS
+TrigReport        171       1000       1000          0          0 CaloHitMakerFast
+TrigReport        171       1000       1000          0          0 CaloClusterFast
+TrigReport        171       1000       1000          0          0 TTmakeSH
+TrigReport        171       1000       1000          0          0 TTmakePH
+TrigReport        171       1000       1000          0          0 TTDeltaFinder
+TrigReport        171       1000       1000          0          0 TTCalTimePeakFinderUe
+TrigReport        171       1000         78        922          0 cprHelixUeTCFilter
+TrigReport        171         78         78          0          0 TTCalHelixFinderUe
+TrigReport        171         78         78          0          0 TTCalHelixMergerUe
+TrigReport        171         78          2         76          0 cprHelixUeHSFilter
+
+TrigReport ---------- Modules in path: cstCosmicTrackSeed ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        320       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        320       1000          0       1000          0 cstCosmicTrackSeedPS
+TrigReport        320          0          0          0          0 TTmakeSH
+TrigReport        320          0          0          0          0 TTmakePH
+TrigReport        320          0          0          0          0 cstCosmicTrackSeedSDCountFilter
+TrigReport        320          0          0          0          0 CstSimpleTimeCluster
+TrigReport        320          0          0          0          0 cstCosmicTrackSeedTCFilter
+TrigReport        320          0          0          0          0 CstLineFinder
+TrigReport        320          0          0          0          0 cstCosmicTrackSeedCTSFilter
+TrigReport        320          0          0          0          0 cstCosmicTrackSeedTriggerInfoMerger
+
+TrigReport ---------- Modules in path: cstTimeCluster ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        310       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        310       1000          0       1000          0 cstTimeClusterPS
+TrigReport        310          0          0          0          0 TTmakeSH
+TrigReport        310          0          0          0          0 TTmakePH
+TrigReport        310          0          0          0          0 cstTimeClusterSDCountFilter
+TrigReport        310          0          0          0          0 CstSimpleTimeCluster
+TrigReport        310          0          0          0          0 cstTimeClusterTCFilter
+TrigReport        310          0          0          0          0 cstTimeClusterTriggerInfoMerger
+
+TrigReport ---------- Modules in path: minBias_CDCount ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        410       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        410       1000          0       1000          0 minBiasCDCountPS
+TrigReport        410          0          0          0          0 minBiasCDCountFilter
+
+TrigReport ---------- Modules in path: minBias_SDCount ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        400       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        400       1000          0       1000          0 minBiasSDCountPS
+TrigReport        400          0          0          0          0 minBiasSDCountFilter
+
+TrigReport ---------- Modules in path: mprDe_highP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        210       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        210       1000       1000          0          0 mprDeHighPStopTargPS
+TrigReport        210       1000       1000          0          0 CaloHitMakerFast
+TrigReport        210       1000       1000          0          0 CaloClusterFast
+TrigReport        210       1000       1000          0          0 TTmakeSH
+TrigReport        210       1000       1000          0          0 TTmakePH
+TrigReport        210       1000       1000          0          0 TTDeltaFinder
+TrigReport        210       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        210       1000        992          8          0 mprDeHighPStopTargTCFilter
+TrigReport        210        992        992          0          0 TTRobustMultiHelixFinder
+TrigReport        210        992        992          0          0 TTMprHelixMergerDe
+TrigReport        210        992        609        383          0 mprDeHighPStopTargHSFilter
+TrigReport        210        609        609          0          0 TTMprKSFDe
+TrigReport        210        609         17        592          0 mprDeHighPStopTargKSFilter
+TrigReport        210         17         17          0          0 mprDeHighPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprDe_highP ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        101       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        101       1000       1000          0          0 tprDeHighPPS
+TrigReport        101       1000       1000          0          0 CaloHitMakerFast
+TrigReport        101       1000       1000          0          0 CaloClusterFast
+TrigReport        101       1000       1000          0          0 TTmakeSH
+TrigReport        101       1000       1000          0          0 TTmakePH
+TrigReport        101       1000       1000          0          0 TTDeltaFinder
+TrigReport        101       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        101       1000        992          8          0 tprDeHighPTCFilter
+TrigReport        101        992        992          0          0 TThelixFinder
+TrigReport        101        992        992          0          0 TTHelixMergerDe
+TrigReport        101        992         57        935          0 tprDeHighPHSFilter
+TrigReport        101         57         57          0          0 TTKSFDe
+TrigReport        101         57          0         57          0 tprDeHighPKSFilter
+TrigReport        101          0          0          0          0 tprDeHighPTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprDe_highP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        100       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        100       1000       1000          0          0 tprDeHighPStopTargPS
+TrigReport        100       1000       1000          0          0 CaloHitMakerFast
+TrigReport        100       1000       1000          0          0 CaloClusterFast
+TrigReport        100       1000       1000          0          0 TTmakeSH
+TrigReport        100       1000       1000          0          0 TTmakePH
+TrigReport        100       1000       1000          0          0 TTDeltaFinder
+TrigReport        100       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        100       1000        992          8          0 tprDeHighPStopTargTCFilter
+TrigReport        100        992        992          0          0 TThelixFinder
+TrigReport        100        992        992          0          0 TTHelixMergerDe
+TrigReport        100        992         35        957          0 tprDeHighPStopTargHSFilter
+TrigReport        100         35         35          0          0 TTKSFDe
+TrigReport        100         35          0         35          0 tprDeHighPStopTargKSFilter
+TrigReport        100          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprDe_lowP_stopTarg ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        110       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        110       1000       1000          0          0 tprDeLowPStopTargPS
+TrigReport        110       1000       1000          0          0 CaloHitMakerFast
+TrigReport        110       1000       1000          0          0 CaloClusterFast
+TrigReport        110       1000       1000          0          0 TTmakeSH
+TrigReport        110       1000       1000          0          0 TTmakePH
+TrigReport        110       1000       1000          0          0 TTDeltaFinder
+TrigReport        110       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        110       1000        998          2          0 tprDeLowPStopTargTCFilter
+TrigReport        110        998        998          0          0 TThelixFinder
+TrigReport        110        998        998          0          0 TTHelixMergerDe
+TrigReport        110        998         96        902          0 tprDeLowPStopTargHSFilter
+TrigReport        110         96         96          0          0 TTKSFDe
+TrigReport        110         96         11         85          0 tprDeLowPStopTargKSFilter
+TrigReport        110         11         11          0          0 tprDeLowPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprHelixDe ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        130       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        130       1000       1000          0          0 tprHelixDePS
+TrigReport        130       1000       1000          0          0 CaloHitMakerFast
+TrigReport        130       1000       1000          0          0 CaloClusterFast
+TrigReport        130       1000       1000          0          0 TTmakeSH
+TrigReport        130       1000       1000          0          0 TTmakePH
+TrigReport        130       1000       1000          0          0 TTDeltaFinder
+TrigReport        130       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        130       1000        992          8          0 tprHelixDeTCFilter
+TrigReport        130        992        992          0          0 TThelixFinder
+TrigReport        130        992        992          0          0 TTHelixMergerDe
+TrigReport        130        992         74        918          0 tprHelixDeHSFilter
+TrigReport        130         74         74          0          0 tprHelixDeTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprHelixDe_ipa ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        120       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        120       1000       1000          0          0 tprHelixDeIpaPS
+TrigReport        120       1000       1000          0          0 CaloHitMakerFast
+TrigReport        120       1000       1000          0          0 CaloClusterFast
+TrigReport        120       1000       1000          0          0 TTmakeSH
+TrigReport        120       1000       1000          0          0 TTmakePH
+TrigReport        120       1000       1000          0          0 TTDeltaFinder
+TrigReport        120       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        120       1000        992          8          0 tprHelixDeIpaTCFilter
+TrigReport        120        992        992          0          0 TThelixFinder
+TrigReport        120        992        992          0          0 TTHelixMergerDe
+TrigReport        120        992         29        963          0 tprHelixDeIpaHSFilter
+TrigReport        120         29         29          0          0 tprHelixDeIpaTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprHelixDe_ipa_phiScaled ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        121       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        121       1000       1000          0          0 tprHelixDeIpaPhiScaledPS
+TrigReport        121       1000       1000          0          0 CaloHitMakerFast
+TrigReport        121       1000       1000          0          0 CaloClusterFast
+TrigReport        121       1000       1000          0          0 TTmakeSH
+TrigReport        121       1000       1000          0          0 TTmakePH
+TrigReport        121       1000       1000          0          0 TTDeltaFinder
+TrigReport        121       1000       1000          0          0 TTtimeClusterFinder
+TrigReport        121       1000        992          8          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport        121        992        992          0          0 TThelixFinder
+TrigReport        121        992        992          0          0 TTHelixMergerDe
+TrigReport        121        992          7        985          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport        121          7          7          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+
+TrigReport ---------- Modules in path: tprHelixUe ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        131       1000       1000          0          0 artFragFromDTCEvents
+TrigReport        131       1000       1000          0          0 tprHelixUePS
+TrigReport        131       1000       1000          0          0 CaloHitMakerFast
+TrigReport        131       1000       1000          0          0 CaloClusterFast
+TrigReport        131       1000       1000          0          0 TTmakeSH
+TrigReport        131       1000       1000          0          0 TTmakePH
+TrigReport        131       1000       1000          0          0 TTDeltaFinder
+TrigReport        131       1000       1000          0          0 TTtimeClusterFinderUe
+TrigReport        131       1000        991          9          0 tprHelixUeTCFilter
+TrigReport        131        991        991          0          0 TThelixFinderUe
+TrigReport        131        991        991          0          0 TTHelixMergerUe
+TrigReport        131        991         90        901          0 tprHelixUeHSFilter
+TrigReport        131         90         90          0          0 tprHelixUeTriggerInfoMerger
+
+TrigReport ---------- Module summary ------------
+TrigReport    Visited        Run     Passed     Failed      Error Name
+TrigReport      22000       1000       1000          0          0 CaloClusterFast
+TrigReport      22000       1000       1000          0          0 CaloHitMakerFast
+TrigReport          0          0          0          0          0 CstLineFinder
+TrigReport          0          0          0          0          0 CstSimpleTimeCluster
+TrigReport       4005        801        801          0          0 TTAprHelixFinder
+TrigReport       4005        801        801          0          0 TTAprHelixMerger
+TrigReport         16         12         12          0          0 TTAprKSF
+TrigReport        348         87         87          0          0 TTCalHelixFinderDe
+TrigReport         78         78         78          0          0 TTCalHelixFinderUe
+TrigReport        348         87         87          0          0 TTCalHelixMergerDe
+TrigReport         78         78         78          0          0 TTCalHelixMergerUe
+TrigReport          4          4          4          0          0 TTCalSeedFitDe
+TrigReport       4000       1000       1000          0          0 TTCalTimePeakFinder
+TrigReport       1000       1000       1000          0          0 TTCalTimePeakFinderUe
+TrigReport      18000       1000       1000          0          0 TTDeltaFinder
+TrigReport       5958        998        998          0          0 TTHelixMergerDe
+TrigReport        991        991        991          0          0 TTHelixMergerUe
+TrigReport        188        101        101          0          0 TTKSFDe
+TrigReport        992        992        992          0          0 TTMprHelixMergerDe
+TrigReport        609        609        609          0          0 TTMprKSFDe
+TrigReport        992        992        992          0          0 TTRobustMultiHelixFinder
+TrigReport       5000       1000       1000          0          0 TTTZClusterFinder
+TrigReport       5958        998        998          0          0 TThelixFinder
+TrigReport        991        991        991          0          0 TThelixFinderUe
+TrigReport      18000       1000       1000          0          0 TTmakePH
+TrigReport      18000       1000       1000          0          0 TTmakeSH
+TrigReport       7000       1000       1000          0          0 TTtimeClusterFinder
+TrigReport       1000       1000       1000          0          0 TTtimeClusterFinderUe
+TrigReport        801        801         12        789          0 aprHelixHSFilter
+TrigReport       1000       1000        801        199          0 aprHelixTCFilter
+TrigReport         12         12         12          0          0 aprHelixTriggerInfoMerger
+TrigReport        801        801          9        792          0 aprHighPHSFilter
+TrigReport          9          9          0          9          0 aprHighPKSFilter
+TrigReport       1000       1000       1000          0          0 aprHighPPS
+TrigReport        801        801          1        800          0 aprHighPStopTargHSFilter
+TrigReport          1          1          0          1          0 aprHighPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 aprHighPStopTargPS
+TrigReport       1000       1000        801        199          0 aprHighPStopTargTCFilter
+TrigReport          0          0          0          0          0 aprHighPStopTargTriggerInfoMerger
+TrigReport       1000       1000        801        199          0 aprHighPTCFilter
+TrigReport          0          0          0          0          0 aprHighPTriggerInfoMerger
+TrigReport        801        801          6        795          0 aprLowPStopTargHSFilter
+TrigReport          6          6          0          6          0 aprLowPStopTargKSFilter
+TrigReport        801        801          0        801          0 aprLowPStopTargMultiTrkHSFilter
+TrigReport          0          0          0          0          0 aprLowPStopTargMultiTrkKSFilter
+TrigReport       1000       1000       1000          0          0 aprLowPStopTargMultiTrkPS
+TrigReport       1000       1000        801        199          0 aprLowPStopTargMultiTrkTCFilter
+TrigReport          0          0          0          0          0 aprLowPStopTargMultiTrkTriggerInfoMerger
+TrigReport       2000       1000       1000          0          0 aprLowPStopTargPS
+TrigReport       1000       1000        801        199          0 aprLowPStopTargTCFilter
+TrigReport          0          0          0          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport      27000       1000       1000          0          0 artFragFromDTCEvents
+TrigReport       1000       1000          0       1000          0 caloFastCosmicFilter
+TrigReport       1000       1000       1000          0          0 caloFastCosmicPS
+TrigReport       1000       1000         83        917          0 caloFastMVANNCEFilter
+TrigReport       1000       1000       1000          0          0 caloFastMVANNCEPS
+TrigReport       1000       1000         25        975          0 caloFastPhotonFilter
+TrigReport       1000       1000       1000          0          0 caloFastPhotonPS
+TrigReport       1000       1000          0       1000          0 caloFastRMCFilter
+TrigReport       1000       1000       1000          0          0 caloFastRMCPS
+TrigReport          0          0          0          0          0 caloHitRecN0SourceFilter
+TrigReport       1000       1000          0       1000          0 caloHitRecN0SourcePS
+TrigReport         87         87          1         86          0 cprDeHighPHSFilter
+TrigReport          1          1          0          1          0 cprDeHighPKSFilter
+TrigReport       1000       1000       1000          0          0 cprDeHighPPS
+TrigReport         87         87          0         87          0 cprDeHighPStopTargHSFilter
+TrigReport          0          0          0          0          0 cprDeHighPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 cprDeHighPStopTargPS
+TrigReport       1000       1000         87        913          0 cprDeHighPStopTargTCFilter
+TrigReport          0          0          0          0          0 cprDeHighPStopTargTriggerInfoMerger
+TrigReport       1000       1000         87        913          0 cprDeHighPTCFilter
+TrigReport          0          0          0          0          0 cprDeHighPTriggerInfoMerger
+TrigReport         87         87          3         84          0 cprDeLowPStopTargHSFilter
+TrigReport          3          3          0          3          0 cprDeLowPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 cprDeLowPStopTargPS
+TrigReport       1000       1000         87        913          0 cprDeLowPStopTargTCFilter
+TrigReport          0          0          0          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport         87         87          4         83          0 cprHelixDeHSFilter
+TrigReport       1000       1000       1000          0          0 cprHelixDePS
+TrigReport       1000       1000         87        913          0 cprHelixDeTCFilter
+TrigReport          4          4          4          0          0 cprHelixDeTriggerInfoMerger
+TrigReport         78         78          2         76          0 cprHelixUeHSFilter
+TrigReport       1000       1000       1000          0          0 cprHelixUePS
+TrigReport       1000       1000         78        922          0 cprHelixUeTCFilter
+TrigReport          0          0          0          0          0 cstCosmicTrackSeedCTSFilter
+TrigReport       1000       1000          0       1000          0 cstCosmicTrackSeedPS
+TrigReport          0          0          0          0          0 cstCosmicTrackSeedSDCountFilter
+TrigReport          0          0          0          0          0 cstCosmicTrackSeedTCFilter
+TrigReport          0          0          0          0          0 cstCosmicTrackSeedTriggerInfoMerger
+TrigReport       1000       1000          0       1000          0 cstTimeClusterPS
+TrigReport          0          0          0          0          0 cstTimeClusterSDCountFilter
+TrigReport          0          0          0          0          0 cstTimeClusterTCFilter
+TrigReport          0          0          0          0          0 cstTimeClusterTriggerInfoMerger
+TrigReport          0          0          0          0          0 minBiasCDCountFilter
+TrigReport       1000       1000          0       1000          0 minBiasCDCountPS
+TrigReport          0          0          0          0          0 minBiasSDCountFilter
+TrigReport       1000       1000          0       1000          0 minBiasSDCountPS
+TrigReport        992        992        609        383          0 mprDeHighPStopTargHSFilter
+TrigReport        609        609         17        592          0 mprDeHighPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 mprDeHighPStopTargPS
+TrigReport       1000       1000        992          8          0 mprDeHighPStopTargTCFilter
+TrigReport         17         17         17          0          0 mprDeHighPStopTargTriggerInfoMerger
+TrigReport        992        992         57        935          0 tprDeHighPHSFilter
+TrigReport         57         57          0         57          0 tprDeHighPKSFilter
+TrigReport       1000       1000       1000          0          0 tprDeHighPPS
+TrigReport        992        992         35        957          0 tprDeHighPStopTargHSFilter
+TrigReport         35         35          0         35          0 tprDeHighPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 tprDeHighPStopTargPS
+TrigReport       1000       1000        992          8          0 tprDeHighPStopTargTCFilter
+TrigReport          0          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
+TrigReport       1000       1000        992          8          0 tprDeHighPTCFilter
+TrigReport          0          0          0          0          0 tprDeHighPTriggerInfoMerger
+TrigReport        998        998         96        902          0 tprDeLowPStopTargHSFilter
+TrigReport         96         96         11         85          0 tprDeLowPStopTargKSFilter
+TrigReport       1000       1000       1000          0          0 tprDeLowPStopTargPS
+TrigReport       1000       1000        998          2          0 tprDeLowPStopTargTCFilter
+TrigReport         11         11         11          0          0 tprDeLowPStopTargTriggerInfoMerger
+TrigReport        992        992         74        918          0 tprHelixDeHSFilter
+TrigReport        992        992         29        963          0 tprHelixDeIpaHSFilter
+TrigReport       1000       1000       1000          0          0 tprHelixDeIpaPS
+TrigReport        992        992          7        985          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport       1000       1000       1000          0          0 tprHelixDeIpaPhiScaledPS
+TrigReport       1000       1000        992          8          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport          7          7          7          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+TrigReport       1000       1000        992          8          0 tprHelixDeIpaTCFilter
+TrigReport         29         29         29          0          0 tprHelixDeIpaTriggerInfoMerger
+TrigReport       1000       1000       1000          0          0 tprHelixDePS
+TrigReport       1000       1000        992          8          0 tprHelixDeTCFilter
+TrigReport         74         74         74          0          0 tprHelixDeTriggerInfoMerger
+TrigReport        991        991         90        901          0 tprHelixUeHSFilter
+TrigReport       1000       1000       1000          0          0 tprHelixUePS
+TrigReport       1000       1000        991          9          0 tprHelixUeTCFilter
+TrigReport         90         90         90          0          0 tprHelixUeTriggerInfoMerger
+
+TimeReport ---------- Time summary [sec] -------
+TimeReport CPU = 17.766824 Real = 18.293343
+
+MemReport  ---------- Memory summary [base-10 MB] ------
+MemReport  VmPeak = 1496.87 VmHWM = 571.617
+
+Art has completed and will exit with status 0.


### PR DESCRIPTION
Add CI test for trigger paths. This processes data-like digi files on cvmfs and compares the log output to a reference log.

The test returns a status 0 for pass, 1 for warning, and 2 for fail. A failure is currently defined as a trigger path count changes by 4 or more or the average time per event changes by 25%. A minor failure is when there is no major failure but a path count changes by some event or the average time per event changes by 15%. Currently the test takes 5-6 minutes to run locally, processing 20k events.

Example usage:
```
cd $MUSE_WORK_DIR
./mu2e_trig_config/ci/check_trigger_results.sh
```