### PR TITLE
Update to use a reference to fit direction labels

### DIFF
--- a/ci/check_trigger_results.py
+++ b/ci/check_trigger_results.py
@@ -86,11 +86,13 @@ for path in results_1:
                 print(">>> Path " + path + " has a major change!")
                 print("Local counts    :", counts_1)
                 print("Reference counts:", counts_2)
+                break
             elif delta >= count_minor_threshold:
                 minor_fail = True
                 print(">>> Path " + path + " has a minor change:")
                 print("Local counts    :", counts_1)
                 print("Reference counts:", counts_2)
+                break
     else:
         print(">>> New trigger path " + path + " in local found, not in the reference!")
         major_fail = True

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -65,7 +65,7 @@ TrigAprFilters:{
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 200
@@ -83,7 +83,7 @@ TrigAprFilters:{
       {#cuts for downstreeam e-plus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 200
@@ -156,7 +156,7 @@ TrigAprFilters:{
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 600
@@ -174,7 +174,7 @@ TrigAprFilters:{
       {#cuts for downstreeam e-plus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 600
@@ -248,7 +248,7 @@ TrigAprFilters:{
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 200
@@ -266,7 +266,7 @@ TrigAprFilters:{
       {#cuts for downstreeam e-plus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 200
@@ -341,7 +341,7 @@ TrigAprFilters:{
       { #cuts for downstreeam e-minus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         maxChi2DOF: 20
         maxD0: 600.
@@ -359,7 +359,7 @@ TrigAprFilters:{
       { #cuts for downstreeam e-plus
         doParticleTypeCheck: false
         doZPropDirCheck: true
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         maxChi2DOF: 20
         maxD0: 600 #150

--- a/core/filters/trigCprFilters.fcl
+++ b/core/filters/trigCprFilters.fcl
@@ -65,7 +65,7 @@ TrigCprFilters:{
     module_type: "KalSeedFilter"
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -83,7 +83,7 @@ TrigCprFilters:{
         requireCaloCluster: false
       },
       { #cuts for downstream e-plus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -156,7 +156,7 @@ TrigCprFilters:{
     module_type: "KalSeedFilter"
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -174,7 +174,7 @@ TrigCprFilters:{
         requireCaloCluster: false
       },
       { #cuts for downstream e-plus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -247,7 +247,7 @@ TrigCprFilters:{
     module_type: "KalSeedFilter"
     KalSeedCuts : [
       { #cuts for downstream e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -265,7 +265,7 @@ TrigCprFilters:{
         requireCaloCluster: false
       },
       { #cuts for downstream e-plus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true

--- a/core/filters/trigMprFilters.fcl
+++ b/core/filters/trigMprFilters.fcl
@@ -59,7 +59,7 @@ TrigMprFilters:{
     kalSeedCollection: "TTMprKSFDe"
     KalSeedCuts : [
       { #cuts for doesntream e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -77,7 +77,7 @@ TrigMprFilters:{
         requireCaloCluster: false
       },
       {
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true

--- a/core/filters/trigTprFilters.fcl
+++ b/core/filters/trigTprFilters.fcl
@@ -71,7 +71,7 @@ TrigTprFilters:{
     kalSeedCollection: "TTKSFDe"
     KalSeedCuts : [
       { #cuts for doesntream e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -89,7 +89,7 @@ TrigTprFilters:{
         requireCaloCluster: false
       },
       {
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -164,7 +164,7 @@ TrigTprFilters:{
     kalSeedCollection: "TTKSFDe"
     KalSeedCuts : [
       { #cuts for doesntream e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -182,7 +182,7 @@ TrigTprFilters:{
         requireCaloCluster: false
       },
       {
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -256,7 +256,7 @@ TrigTprFilters:{
     kalSeedCollection: "TTKSFDe"
     KalSeedCuts: [
       { #cuts for downstream e-minus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: 11
         doParticleTypeCheck: true
         doZPropDirCheck: true
@@ -274,7 +274,7 @@ TrigTprFilters:{
         requireCaloCluster: false
       },
       { #cuts for downstream e-plus
-        fitdirection: 0
+        fitdirection: @local::FitDir.downstream
         fitparticle: -11
         doParticleTypeCheck: true
         doZPropDirCheck: true

--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -41,7 +41,7 @@ TrigAprProducers : {
       HelixSeedCollections   : [ "TTAprHelixMerger" ]
     }
     UsePDGCharge     : false
-    FitDirection     : 0
+    FitDirection     : @local::FitDir.downstream
   }
 
   aprHighPStopTargTriggerInfoMerger: {

--- a/core/producers/trigCprProducers.fcl
+++ b/core/producers/trigCprProducers.fcl
@@ -67,7 +67,7 @@ TrigCprProducers : {
          -1,
          1
       ]
-      fitdirection: 0
+      fitdirection: @local::FitDir.downstream
       fitparticle: 11
       doSingleOutput: true
       maxEDepAvg: 0.0025
@@ -141,7 +141,7 @@ TrigCprProducers : {
          -1,
          1
       ]
-      fitdirection: 0
+      fitdirection: @local::FitDir.downstream
       fitparticle: 11
       doSingleOutput: true
       maxEDepAvg: 0.0025
@@ -242,7 +242,7 @@ TrigCprProducers : {
          FitParticle         : 11
       }
       UsePDGCharge     : false
-      FitDirection     : 0
+      FitDirection     : @local::FitDir.downstream
    }
 
    cprDeHighPStopTargTriggerInfoMerger: {

--- a/core/producers/trigMprProducers.fcl
+++ b/core/producers/trigMprProducers.fcl
@@ -52,7 +52,7 @@ TrigMprProducers : {
       HelixSeedCollections   : [ "TTMprHelixMergerDe" ]
     }
     UsePDGCharge     : false
-    FitDirection     : 0
+    FitDirection     : @local::FitDir.downstream
   }
 
   mprDeHighPStopTargTriggerInfoMerger: {

--- a/core/producers/trigTprProducers.fcl
+++ b/core/producers/trigTprProducers.fcl
@@ -186,7 +186,7 @@ TrigTprProducers : {
       HelixSeedCollections   : [ "TTHelixMergerDe" ]
     }
     UsePDGCharge     : false
-    FitDirection     : 0
+    FitDirection     : @local::FitDir.downstream
   }
 
   TTKSFUe: {
@@ -201,7 +201,7 @@ TrigTprProducers : {
       HelixSeedCollections   : [ "TTHelixMergerUe" ]
     }
     UsePDGCharge     : false
-    FitDirection     : 1
+    FitDirection     : @local::FitDir.upstream
   }
 
   TThelixFinderUe: {

--- a/core/trigProducers.fcl
+++ b/core/trigProducers.fcl
@@ -2,6 +2,7 @@
 # this file includes all the prolog needed to run the reconstruction
 # at the trigger level and the filters used to make the trigger decision
 #------------------------------------------------------------------------------
+#include "Offline/TrkPatRec/fcl/Particle.fcl"
 #include "Offline/TrkHitReco/fcl/prolog.fcl"
 #include "Offline/Mu2eKinKal/fcl/prolog.fcl"
 #include "Offline/TrkReco/fcl/prolog.fcl"


### PR DESCRIPTION
In connection to Offline PR: https://github.com/Mu2e/Offline/pull/1401
The helix reco direction and track fit direction enums are consolidated and modules now take the fit direction names ("downstream" and "upstream") rather than coded integer values (0 and 1 or 1 and -1, respectively). I updated to use the proper definitions of these in Offline/TrkPatRec/fcl/Particle.fcl.